### PR TITLE
cloudformation: add autoscaling:DescribeTags right to template

### DIFF
--- a/cloudformation/stacks/AutoSpotting/template.json
+++ b/cloudformation/stacks/AutoSpotting/template.json
@@ -84,6 +84,7 @@
                 "autoscaling:DescribeLaunchConfigurations",
                 "autoscaling:AttachInstances",
                 "autoscaling:DetachInstances",
+		"autoscaling:DescribeTags",
                 "ec2:CreateTags",
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions",


### PR DESCRIPTION
The IAM role used by the lambda function needed to be updated in order
to get the ASG tags. It currently did not have it, which resulted in:

```
region.go:248: Failed to describe AutoScaling tags in us-east-1
AccessDenied: User:
arn:aws:sts::308824460317:assumed-role/AutoSpotting-LambdaExecutionRole-17GHN91Z6W9OE/AutoSpotting-LambdaFunction-V9LHZ91FKJK4
is not authorized to perform: autoscaling:DescribeTags
```

Solves: https://github.com/cristim/autospotting/issues/49