### PR TITLE
Fix copying of block device mappings

### DIFF
--- a/core/launch_configuration.go
+++ b/core/launch_configuration.go
@@ -110,9 +110,10 @@ func copyBlockDeviceMappings(
 	lcBDMs []*autoscaling.BlockDeviceMapping) []*ec2.BlockDeviceMapping {
 
 	var ec2BDMlist []*ec2.BlockDeviceMapping
-	var ec2BDM ec2.BlockDeviceMapping
 
 	for _, lcBDM := range lcBDMs {
+		var ec2BDM ec2.BlockDeviceMapping
+
 		ec2BDM.DeviceName = lcBDM.DeviceName
 
 		// EBS volume information

--- a/core/launch_configuration_test.go
+++ b/core/launch_configuration_test.go
@@ -1,0 +1,106 @@
+package autospotting
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func Test_copyBlockDeviceMappings(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		asbdm []*autoscaling.BlockDeviceMapping
+		want  []*ec2.BlockDeviceMapping
+	}{{name: "instance-store only",
+		asbdm: []*autoscaling.BlockDeviceMapping{
+			&autoscaling.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/ephemeral0"),
+				Ebs:         nil,
+				NoDevice:    aws.Bool(false),
+				VirtualName: aws.String("foo"),
+			},
+			&autoscaling.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/ephemeral1"),
+				Ebs:         nil,
+				NoDevice:    aws.Bool(false),
+				VirtualName: aws.String("bar"),
+			},
+		},
+		want: []*ec2.BlockDeviceMapping{
+			&ec2.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/ephemeral0"),
+				Ebs:         nil,
+				NoDevice:    aws.String("false"),
+				VirtualName: aws.String("foo"),
+			},
+			&ec2.BlockDeviceMapping{
+				DeviceName:  aws.String("/dev/ephemeral1"),
+				Ebs:         nil,
+				NoDevice:    aws.String("false"),
+				VirtualName: aws.String("bar"),
+			},
+		},
+	},
+		{name: "instance-store and EBS",
+			asbdm: []*autoscaling.BlockDeviceMapping{
+				&autoscaling.BlockDeviceMapping{
+					DeviceName:  aws.String("/dev/ephemeral0"),
+					Ebs:         nil,
+					NoDevice:    aws.Bool(false),
+					VirtualName: aws.String("foo"),
+				},
+				&autoscaling.BlockDeviceMapping{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &autoscaling.Ebs{
+						DeleteOnTermination: aws.Bool(false),
+						VolumeSize:          aws.Int64(10),
+					},
+					VirtualName: aws.String("bar"),
+				},
+				&autoscaling.BlockDeviceMapping{
+					DeviceName: aws.String("/dev/xvdb"),
+					Ebs: &autoscaling.Ebs{
+						DeleteOnTermination: aws.Bool(true),
+						VolumeSize:          aws.Int64(20),
+					},
+					VirtualName: aws.String("baz"),
+				},
+			},
+			want: []*ec2.BlockDeviceMapping{
+				&ec2.BlockDeviceMapping{
+					DeviceName:  aws.String("/dev/ephemeral0"),
+					Ebs:         nil,
+					NoDevice:    aws.String("false"),
+					VirtualName: aws.String("foo"),
+				},
+				&ec2.BlockDeviceMapping{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(false),
+						VolumeSize:          aws.Int64(10),
+					},
+					VirtualName: aws.String("bar"),
+				},
+				&ec2.BlockDeviceMapping{
+					DeviceName: aws.String("/dev/xvdb"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(true),
+						VolumeSize:          aws.Int64(20),
+					},
+					VirtualName: aws.String("baz"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := copyBlockDeviceMappings(tt.asbdm); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("copyBlockDeviceMappings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes #75, and adds a bunch of tests for the function that copies block device mappings.