### PR TITLE
Run fmt and vet from TravisCI, build cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,7 @@ sudo: required
 services:
 - docker
 
-before_install:
-- go get github.com/mattn/goveralls
-- go get golang.org/x/tools/cmd/cover
-- docker pull eawsy/aws-lambda-go:latest
-- make prepare_bindata
-
-install:
-- go get ./...
-
-script: go test ./core -covermode=count -coverprofile=profile.cov &&
-  goveralls -coverprofile=profile.cov -service=travis-ci &&
-  make prepare_upload_data
+script: make travisci
 
 after_success:
   - curl --request POST "https://goreportcard.com/checks" --data "repo=github.com/cristim/autospotting"

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ LOCAL_PATH := build/s3/dv
 
 DOCKER_IMG := eawsy/aws-lambda-go
 
-GO_FILES := $(shell find ./ -name '*.go')
-
 BINDATA_DIR := data
 BINDATA_FILE := generated_bindata.go
 
@@ -20,37 +18,43 @@ BUILD := $(or $(TRAVIS_BUILD_NUMBER), $(TRAVIS_BUILD_NUMBER), $(SHA))
 EC2_INSTANCES_INFO_COMMIT_SHA := e655e36660bc617713c4ef9a1409cc65a209cb27
 INSTANCES_URL := "https://raw.githubusercontent.com/powdahound/ec2instances.info/$(EC2_INSTANCES_INFO_COMMIT_SHA)/www/instances.json"
 
-all: build_local                                                             ## Build the code
+all: fmt-check vet-check build_local test                                                   ## Build the code
+.PHONY: all
 
-clean:                                                                       ## Remove installed packages/temporary files
+clean:                                                                      ## Remove installed packages/temporary files
 	go clean ./...
 	rm -rf $(BINDATA_DIR) $(BINDATA_FILE)
+.PHONY: clean
 
-check_deps:                                                                  ## Verify the system has all dependencies installed
+check_deps:                                                                 ## Verify the system has all dependencies installed
 	@for DEP in $(shell echo "$(DEPS)"); do \
 		command -v "$$DEP" &>/dev/null \
 		|| (echo "Error: dependency '$$DEP' is absent" ; exit 1); \
 	done
 	@echo "all dependencies satisifed: $(DEPS)"
+.PHONY: check_deps
 
 build_deps:
 	@go get github.com/mattn/goveralls
 	@go get golang.org/x/tools/cmd/cover
 	@docker pull eawsy/aws-lambda-go:latest
+.PHONY: build_deps
 
-prepare_bindata: check_deps build_deps                                       ## Convert instance data into go file
+prepare_bindata: check_deps build_deps                                      ## Convert instance data into go file
 	go get ./...
 	@type go-bindata || go get -u github.com/jteeuwen/go-bindata/...
 	@mkdir -p $(BINDATA_DIR)
 	wget --quiet -nv $(INSTANCES_URL) -O $(BINDATA_DIR)/instances.json
 	@echo $(BUILD) > $(BINDATA_DIR)/BUILD
 	go-bindata -o $(BINDATA_FILE) -nometadata $(BINDATA_DIR)
-	@gofmt -w $(BINDATA_FILE)
+	gofmt -l -s -w $(BINDATA_FILE)
+.PHONY: prepare_bindata
 
-build_lambda_binary: bindata                                                 ## Build lambda binary
+build_lambda_binary: prepare_bindata                                        ## Build lambda binary
 	docker run --rm -v $(GOPATH):/go -v $(PWD):/tmp $(DOCKER_IMG)
+.PHONY: build_lambda_binary
 
-prepare_upload_data: build_lambda_binary                                     ## Create archive to be uploaded
+prepare_upload_data: build_lambda_binary                                    ## Create archive to be uploaded
 	@rm -rf $(LOCAL_PATH)
 	@mkdir -p $(LOCAL_PATH)
 	@mv handler.zip $(LOCAL_PATH)/lambda.zip
@@ -58,47 +62,61 @@ prepare_upload_data: build_lambda_binary                                     ## 
 	@cp -f cloudformation/stacks/AutoSpotting/template.json $(LOCAL_PATH)/template_build_$(BUILD).json
 	@cp -f $(LOCAL_PATH)/lambda.zip $(LOCAL_PATH)/lambda_build_$(BUILD).zip
 	@cp -f $(LOCAL_PATH)/lambda.zip $(LOCAL_PATH)/lambda_build_$(SHA).zip
+.PHONY: prepare_upload_data
 
-build_local: bindata                                                         ## Build binary - local dev
+build_local: prepare_bindata                                                ## Build binary - local dev
 	go build $(GOFLAGS) -o $(BINARY)
+.PHONY: build_local
 
-upload: prepare_upload_data                                                  ## Upload binary
+upload: prepare_upload_data                                                 ## Upload binary
 	aws s3 sync build/s3/ s3://$(BUCKET_NAME)/
+.PHONY: upload
 
-vet-check:                                                                   ## Verify vet compliance
+vet-check:                                                                  ## Verify vet compliance
 ifeq ($(shell go tool vet -all -shadow=true . 2>&1 | wc -l), 0)
 	@printf "ok\tall files passed go vet\n"
 else
 	@printf "error\tsome files did not pass go vet\n"
 	@go tool vet -all -shadow=true . 2>&1
 endif
+.PHONY: vet-check
 
-fmt-check:                                                                   ## Verify fmt compliance
-ifneq ($(shell gofmt -l -s $(GO_FILES) | wc -l), 0)
-	@printf "error\tsome files did not pass go fmt, fix the following formatting diff\n"
-	@gofmt -l -s -d $(GO_FILES)
+fmt:
+	gofmt -l -s -w .
+.PHONY: fmt
+
+fmt-check:                                                                  ## Verify fmt compliance
+ifneq ($(shell gofmt -l -s . | wc -l), 0)
+	@printf "error\tsome files did not pass go fmt, fix the following formatting diff or run 'make fmt'\n"
+	@gofmt -l -s -d .
 	@exit 1
 else
 	@printf "ok\tall files passed go fmt\n"
 endif
+.PHONY: fmt-check
 
-test:                                                                        ## Test go code and coverage
+test:                                                                       ## Test go code and coverage
 	@go test -covermode=count -coverprofile=$(COVER_PROFILE) $(BINARY_PKG)
+.PHONY: test
 
-full-test: fmt-check vet-check test                                          ## Pass test / fmt / vet
+full-test: fmt-check vet-check test                                         ## Pass test / fmt / vet
+.PHONY: full-test
 
-html-cover: test                                                             ## Display coverage in HTML
+html-cover: test                                                            ## Display coverage in HTML
 	@go tool cover -html=$(COVER_PROFILE)
+.PHONY: html-cover
 
-travisci-cover: html-cover                                                   ## Generate coverage in the TravisCI format, fails unless executed from TravisCI
+travisci-cover: html-cover                                                  ## Generate coverage in the TravisCI format, fails unless executed from TravisCI
 	@goveralls -coverprofile=$(COVER_PROFILE) -service=travis-ci
+.PHONY: travisci-cover
 
-travisci-checks: fmt-check vet-check                                         ## Pass fmt / vet and calculate test coverage
+travisci-checks: fmt-check vet-check                                        ## Pass fmt / vet and calculate test coverage
+.PHONY: travisci-checks
 
-travisci: prepare_bindata travisci-checks prepare_upload_data travisci-cover ## Executed by TravisCI
+travisci: prepare_bindata travisci-checks prepare_upload_data travisci-cover## Executed by TravisCI
+.PHONY: travisci
 
-help:                                                                        ## Show this help
+help:                                                                       ## Show this help
 	@printf "Rules:\n"
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
-
-.PHONY: all clean check_dep bindata build_lambda_binary prepare_upload_data build_local upload vet-check fmt-check check_deps prepare_bindata test full-test html-cover help travisci-checks travisci-cover travisci
+.PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -101,5 +101,4 @@ help:                                                                        ## 
 	@printf "Rules:\n"
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 
-.PHONY: all clean check_dep bindata build_lambda_binary prepare_upload_data build_local upload vet-check fmt-check
-.PHONY: test full-test html-cover help
+.PHONY: all clean check_dep bindata build_lambda_binary prepare_upload_data build_local upload vet-check fmt-check check_deps prepare_bindata test full-test html-cover help travisci-checks travisci-cover travisci

--- a/Makefile
+++ b/Makefile
@@ -20,20 +20,25 @@ BUILD := $(or $(TRAVIS_BUILD_NUMBER), $(TRAVIS_BUILD_NUMBER), $(SHA))
 EC2_INSTANCES_INFO_COMMIT_SHA := e655e36660bc617713c4ef9a1409cc65a209cb27
 INSTANCES_URL := "https://raw.githubusercontent.com/powdahound/ec2instances.info/$(EC2_INSTANCES_INFO_COMMIT_SHA)/www/instances.json"
 
-all: build_local                                             ## Build the code
+all: build_local                                                             ## Build the code
 
-clean:                                                       ## Remove installed packages/temporary files
+clean:                                                                       ## Remove installed packages/temporary files
 	go clean ./...
 	rm -rf $(BINDATA_DIR) $(BINDATA_FILE)
 
-check_dep:                                                   ## Verify the system has all dependencies installed
+check_deps:                                                                  ## Verify the system has all dependencies installed
 	@for DEP in $(shell echo "$(DEPS)"); do \
 		command -v "$$DEP" &>/dev/null \
 		|| (echo "Error: dependency '$$DEP' is absent" ; exit 1); \
 	done
 	@echo "all dependencies satisifed: $(DEPS)"
 
-prepare_bindata: check_dep                                   ## Convert instance data into go file
+build_deps:
+	@go get github.com/mattn/goveralls
+	@go get golang.org/x/tools/cmd/cover
+	@docker pull eawsy/aws-lambda-go:latest
+
+prepare_bindata: check_deps build_deps                                       ## Convert instance data into go file
 	go get ./...
 	@type go-bindata || go get -u github.com/jteeuwen/go-bindata/...
 	@mkdir -p $(BINDATA_DIR)
@@ -42,10 +47,10 @@ prepare_bindata: check_dep                                   ## Convert instance
 	go-bindata -o $(BINDATA_FILE) -nometadata $(BINDATA_DIR)
 	@gofmt -w $(BINDATA_FILE)
 
-build_lambda_binary: bindata                                 ## Build lambda binary
+build_lambda_binary: bindata                                                 ## Build lambda binary
 	docker run --rm -v $(GOPATH):/go -v $(PWD):/tmp $(DOCKER_IMG)
 
-prepare_upload_data: build_lambda_binary                     ## Create archive to be uploaded
+prepare_upload_data: build_lambda_binary                                     ## Create archive to be uploaded
 	@rm -rf $(LOCAL_PATH)
 	@mkdir -p $(LOCAL_PATH)
 	@mv handler.zip $(LOCAL_PATH)/lambda.zip
@@ -54,36 +59,45 @@ prepare_upload_data: build_lambda_binary                     ## Create archive t
 	@cp -f $(LOCAL_PATH)/lambda.zip $(LOCAL_PATH)/lambda_build_$(BUILD).zip
 	@cp -f $(LOCAL_PATH)/lambda.zip $(LOCAL_PATH)/lambda_build_$(SHA).zip
 
-build_local: bindata                                         ## Build binary - local dev
+build_local: bindata                                                         ## Build binary - local dev
 	go build $(GOFLAGS) -o $(BINARY)
 
-upload: prepare_upload_data                                  ## Upload binary
+upload: prepare_upload_data                                                  ## Upload binary
 	aws s3 sync build/s3/ s3://$(BUCKET_NAME)/
 
-vet-check:                                                   ## Verify vet compliance
-ifeq ($(shell go tool vet -all -shadow=true $(GO_FILES) 2>&1 | wc -l), 0)
+vet-check:                                                                   ## Verify vet compliance
+ifeq ($(shell go tool vet -all -shadow=true . 2>&1 | wc -l), 0)
 	@printf "ok\tall files passed go vet\n"
 else
 	@printf "error\tsome files did not pass go vet\n"
-	@go tool vet -all -shadow=true $(GO_FILES) 2>&1
+	@go tool vet -all -shadow=true . 2>&1
 endif
 
-fmt-check:                                                   ## Verify fmt compliance
+fmt-check:                                                                   ## Verify fmt compliance
 ifneq ($(shell gofmt -l -s $(GO_FILES) | wc -l), 0)
-	@printf "error\tsome files did not pass go fmt: $(shell gofmt -l -s $(GO_FILES))\n"; exit 1
+	@printf "error\tsome files did not pass go fmt, fix the following formatting diff\n"
+	@gofmt -l -s -d $(GO_FILES)
+	@exit 1
 else
 	@printf "ok\tall files passed go fmt\n"
 endif
 
-test:                                                        ## Test go code and coverage
+test:                                                                        ## Test go code and coverage
 	@go test -covermode=count -coverprofile=$(COVER_PROFILE) $(BINARY_PKG)
 
-full-test: test fmt-check vet-check                          ## Pass test / fmt / vet
+full-test: fmt-check vet-check test                                          ## Pass test / fmt / vet
 
-html-cover: test                                             ## Display coverage in HTML
+html-cover: test                                                             ## Display coverage in HTML
 	@go tool cover -html=$(COVER_PROFILE)
 
-help:                                                        ## Show this help
+travisci-cover: html-cover                                                   ## Generate coverage in the TravisCI format, fails unless executed from TravisCI
+	@goveralls -coverprofile=$(COVER_PROFILE) -service=travis-ci
+
+travisci-checks: fmt-check vet-check                                         ## Pass fmt / vet and calculate test coverage
+
+travisci: prepare_bindata travisci-checks prepare_upload_data travisci-cover ## Executed by TravisCI
+
+help:                                                                        ## Show this help
 	@printf "Rules:\n"
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 


### PR DESCRIPTION
# Issue Type #

- Feature Pull Request

## Summary ##

This ensures the code fails build verification in case it fails to pass go vet and go fmt. 
It also creates a few additional make targets called from TravisCI so that the Travis config file can be simplified and all the installation of dependencies and build logic is in the Makefile.