### PR TITLE
fix typo in terraform example

### DIFF
--- a/START.md
+++ b/START.md
@@ -119,7 +119,7 @@ module "autospotting" {
   lambda_runtime = "200"
   lambda_memory_size = "2048"
   lambda_timeout = "600"
-  lambda_run_frequency = "rate(1 minute)"
+  lambda_run_frequency = "rate(5 minutes)"
 }
 ```
 

--- a/START.md
+++ b/START.md
@@ -119,7 +119,7 @@ module "autospotting" {
   lambda_runtime = "200"
   lambda_memory_size = "2048"
   lambda_timeout = "600"
-  lambda_run_frequency = "rate(1 minutes)"
+  lambda_run_frequency = "rate(1 minute)"
 }
 ```
 


### PR DESCRIPTION
"rate(1 minutes)" is invalid and isn't accepted by the API.  Should be "rate(1 minute)"
