### PR TITLE
Handler case fix

### DIFF
--- a/START.md
+++ b/START.md
@@ -286,7 +286,7 @@ Travis CI [builds page](https://travis-ci.org/cristim/autospotting/builds)
   binary. Make sure you use the following stack parameter on any newer builds:
 
 ```
-LambdaHandlerFunction: handler.handle
+LambdaHandlerFunction: handler.Handle
 ```
 
 ## Uninstallation ##

--- a/terraform/autospotting/lambda.tf
+++ b/terraform/autospotting/lambda.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "autospotting" {
   role = "${aws_iam_role.autospotting_role.arn}"
   runtime = "${var.lambda_runtime}"
   timeout = "${var.lambda_timeout}"
-  handler = "handler.handle"
+  handler = "handler.Handle"
   memory_size = "${var.lambda_memory_size}"
 
   environment {


### PR DESCRIPTION
# Issue Type #

- Bugfix Pull Request
- Documentation Pull Request

## Summary ##

Wasn't able to get this module working using the included terraform code due to error:
```
Handler 'handler' missing on module 'handler': plugin: symbol handler not found in plugin lambda
```

Digging into the code and comparing to the Cloudformation definition, I could see it is actually defined as "Handle" rather than "handle".  Fixing this allowed it to work.  Also saw reference to "handle" in the documentation so have also tweaked that.
