### PR TITLE
Handle #48 in short-term by using appropriate securitygroup form

### DIFF
--- a/core/launch_configuration.go
+++ b/core/launch_configuration.go
@@ -92,8 +92,22 @@ func (lc *launchConfiguration) convertLaunchConfigurationToSpotSpecification(
 			},
 		}
 	} else {
-		// Instances are running in EC2 Classic.
-		spotLS.SecurityGroups = lc.SecurityGroups
+		// Instances are running in EC2 Classic, but maybe by name or ID
+		// depending on your scenario, so testing if start with sg-
+		// note: this doesn't yet cover scenario of mixed mode
+		ids := true
+
+		for i := range lc.SecurityGroups {
+			if !strings.HasPrefix(*(lc.SecurityGroups[i]), "sg-") {
+				ids = false
+			}
+		}
+
+		if ids {
+			spotLS.SecurityGroupIds = lc.SecurityGroups
+		} else {
+			spotLS.SecurityGroups = lc.SecurityGroups
+		}
 	}
 
 	if lc.UserData != nil && *lc.UserData != "" {

--- a/core/launch_configuration_test.go
+++ b/core/launch_configuration_test.go
@@ -348,6 +348,62 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 			},
 		},
 		{
+			name: "classic-nonid-networking",
+			lc: &launchConfiguration{
+				&autoscaling.LaunchConfiguration{
+					SecurityGroups: aws.StringSlice([]string{"non-sgstart", "non-sg"}),
+				},
+			},
+			instance: &instance{
+				Instance: &ec2.Instance{},
+			},
+			spotRequest: &ec2.RequestSpotLaunchSpecification{
+				InstanceType: aws.String(""),
+				Placement: &ec2.SpotPlacement{
+					AvailabilityZone: aws.String(""),
+				},
+				SecurityGroups: aws.StringSlice([]string{"non-sgstart", "non-sg"}),
+			},
+		},
+		{
+			name: "classic-id-networking",
+			lc: &launchConfiguration{
+				&autoscaling.LaunchConfiguration{
+					SecurityGroups: aws.StringSlice([]string{"sg-12345", "sg-4567"}),
+				},
+			},
+			instance: &instance{
+				Instance: &ec2.Instance{},
+			},
+			spotRequest: &ec2.RequestSpotLaunchSpecification{
+				InstanceType:   aws.String(""),
+				SecurityGroups: nil,
+				Placement: &ec2.SpotPlacement{
+					AvailabilityZone: aws.String(""),
+				},
+				SecurityGroupIds: aws.StringSlice([]string{"sg-12345", "sg-4567"}),
+			},
+		},
+		{
+			name: "classic-mixed-networking",
+			lc: &launchConfiguration{
+				&autoscaling.LaunchConfiguration{
+					SecurityGroups: aws.StringSlice([]string{"sg-12345", "non-sg"}),
+				},
+			},
+			instance: &instance{
+				Instance: &ec2.Instance{},
+			},
+			spotRequest: &ec2.RequestSpotLaunchSpecification{
+				InstanceType:   aws.String(""),
+				SecurityGroups: aws.StringSlice([]string{"sg-12345", "non-sg"}),
+				Placement: &ec2.SpotPlacement{
+					AvailabilityZone: aws.String(""),
+				},
+				SecurityGroupIds: nil,
+			},
+		},
+		{
 			name: "full configuration",
 			lc: &launchConfiguration{
 				&autoscaling.LaunchConfiguration{


### PR DESCRIPTION
# Issue Type #

- Bugfix Pull Request

## Summary ##

Per discussion in #48, we need SecurityGroupId support for non-VPC. This flips between SecurityGroups and SecurityGroupId based off of "sg-", which while not perfect, is a good midterm solution

Confirmed it works in our scenario.