### PR TITLE
Instance Paging and Pending Node Attach Scenarios - covers #98

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -321,8 +321,8 @@ func (a *autoScalingGroup) replaceOnDemandInstanceWithSpot(
 		"replacing with new spot instance", *spotInst.InstanceId)
 	// revert attach/detach order when running on minimum capacity
 	if desiredCapacity == minSize {
-		attach_err := a.attachSpotInstance(spotInstanceID)
-		if attach_err != nil {
+		attachErr := a.attachSpotInstance(spotInstanceID)
+		if attachErr != nil {
 			logger.Println(a.name, "skipping detaching on-demand due to failure to",
 				"attach the new spot instance", *spotInst.InstanceId)
 			return nil

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -1456,9 +1456,6 @@ func TestBidForSpotInstance(t *testing.T) {
 								{InstanceId: aws.String("1")},
 							},
 						},
-						dio: &ec2.DescribeInstancesOutput{
-							Reservations: []*ec2.Reservation{{}},
-						},
 					},
 				},
 			},
@@ -1486,9 +1483,6 @@ func TestBidForSpotInstance(t *testing.T) {
 							SpotInstanceRequests: []*ec2.SpotInstanceRequest{
 								{InstanceId: aws.String("1")},
 							},
-						},
-						dio: &ec2.DescribeInstancesOutput{
-							Reservations: []*ec2.Reservation{{}},
 						},
 					},
 				},
@@ -1518,9 +1512,6 @@ func TestBidForSpotInstance(t *testing.T) {
 								{InstanceId: aws.String("1")},
 							},
 						},
-						dio: &ec2.DescribeInstancesOutput{
-							Reservations: []*ec2.Reservation{{}},
-						},
 					},
 				},
 			},
@@ -1549,9 +1540,6 @@ func TestBidForSpotInstance(t *testing.T) {
 								{InstanceId: aws.String("1")},
 							},
 						},
-						dio: &ec2.DescribeInstancesOutput{
-							Reservations: []*ec2.Reservation{{}},
-						},
 					},
 				},
 			},
@@ -1579,9 +1567,6 @@ func TestBidForSpotInstance(t *testing.T) {
 							SpotInstanceRequests: []*ec2.SpotInstanceRequest{
 								{InstanceId: aws.String("1")},
 							},
-						},
-						dio: &ec2.DescribeInstancesOutput{
-							Reservations: []*ec2.Reservation{{}},
 						},
 					},
 				},

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -1,11 +1,12 @@
 package autospotting
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"testing"
 )
 
 func CheckErrors(t *testing.T, err error, expected error) {
@@ -33,9 +34,8 @@ type mockEC2 struct {
 	// Describe Spot Price History
 	dspho   *ec2.DescribeSpotPriceHistoryOutput
 	dspherr error
-	// Describe Instance
-	dio   *ec2.DescribeInstancesOutput
-	dierr error
+	// Error in DescribeInstancesPages
+	diperr error
 	// Terminate Instance
 	tio   *ec2.TerminateInstancesOutput
 	tierr error
@@ -63,8 +63,8 @@ func (m mockEC2) DescribeSpotPriceHistory(in *ec2.DescribeSpotPriceHistoryInput)
 	return m.dspho, m.dspherr
 }
 
-func (m mockEC2) DescribeInstances(in *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
-	return m.dio, m.dierr
+func (m mockEC2) DescribeInstancesPages(in *ec2.DescribeInstancesInput, fn func(*ec2.DescribeInstancesOutput, bool) bool) error {
+	return m.diperr
 }
 
 func (m mockEC2) TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {

--- a/core/spot_instance_request_test.go
+++ b/core/spot_instance_request_test.go
@@ -47,9 +47,6 @@ func Test_waitForAndTagSpotInstance(t *testing.T) {
 									{InstanceId: aws.String("")},
 								},
 							},
-							dio: &ec2.DescribeInstancesOutput{
-								Reservations: []*ec2.Reservation{{}},
-							},
 						},
 					},
 				},
@@ -77,9 +74,6 @@ func Test_waitForAndTagSpotInstance(t *testing.T) {
 								},
 							},
 							dsirerr: errors.New(""),
-							dio: &ec2.DescribeInstancesOutput{
-								Reservations: []*ec2.Reservation{{}},
-							},
 						},
 					},
 				},


### PR DESCRIPTION
# Issue Type #

- Bugfix Pull Request

## Summary ##

This is a WIP, it needs test updates as the tests currently panic now, at least on Go 1.8 (though running the local version itself is much smoother)

* Fixes #98 by adding paging for instances. I can confirm cause of that for us was having too many instances listed and not finding the spot nodes in the list.
Also, it covers two additional scenarios that also caused leaked and failed nodes in my testing:
* Like Grace Period, we also should not be attempting to add nodes still in pending state - instead, we should wait for next round, similar to grace period. This covers scenario where the pending->running takes longer than grace period timeout.
* Even if we do try to attach, we should still not try to detach if that fails. There's still a defer case for when at max nodes, but this covers the majority of uses. Open to ideas on how to cover the defer case.

With the last 2 specifically, this also made the code run much more reliably for us in local mode when running more than every 5 minutes (though still not recommended), as the code handled the timing there much better in case you ran too fast since it no longer picked up the pending nodes or detached the on-demand nodes too early if the new spot node couldn't attach.
