### PR TITLE
Commenting the Manual Log Group Creation for Lambda

### DIFF
--- a/terraform/autospotting/lambda.tf
+++ b/terraform/autospotting/lambda.tf
@@ -47,9 +47,3 @@ resource "aws_cloudwatch_event_rule" "cloudwatch_frequency" {
   name = "autospotting_frequency"
   schedule_expression = "${var.lambda_run_frequency}"
 }
-
-# Commenting out - as reapplying creates an issue when manually creating the log group for Lambda
-# resource "aws_cloudwatch_log_group" "log_group_autospotting" {
-#   name = "/aws/lambda/${aws_lambda_function.autospotting.function_name}"
-#   retention_in_days = 7
-# }

--- a/terraform/autospotting/lambda.tf
+++ b/terraform/autospotting/lambda.tf
@@ -48,7 +48,8 @@ resource "aws_cloudwatch_event_rule" "cloudwatch_frequency" {
   schedule_expression = "${var.lambda_run_frequency}"
 }
 
-resource "aws_cloudwatch_log_group" "log_group_autospotting" {
-  name = "/aws/lambda/${aws_lambda_function.autospotting.function_name}"
-  retention_in_days = 7
-}
+# Commenting out - as reapplying creates an issue when manually creating the log group for Lambda
+# resource "aws_cloudwatch_log_group" "log_group_autospotting" {
+#   name = "/aws/lambda/${aws_lambda_function.autospotting.function_name}"
+#   retention_in_days = 7
+# }


### PR DESCRIPTION
# Issue Type #

- Bugfix Pull Request

## Summary ##

Terraform template for Auto-Spotting manually creates the Log group for the Lambda function. The issue with destroy and apply cycle of the terraform template - the log group is not deleted - results in error; also, the lambda functions automatically create the log group for any lambda function deployed. 

The below changes comments out the Terraform template for log group creation, as the Lambda function automatically creates the log group - if the role associated with the Lambda function has permissions to create the log group.
