### PR TITLE
[WIP] spotRequest: tag logic directly into the request

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -419,7 +419,7 @@ func (a *autoScalingGroup) havingReadyToAttachSpotInstance() (*string, bool) {
 			// function timeout when waiting for the instances would break the loop,
 			// because the subsequent run would find a failed spot request instead
 			// of an open one.
-			req.waitForAndTagSpotInstance()
+			req.waitForSpotInstance()
 			activeSpotInstanceRequest = req
 		}
 
@@ -451,7 +451,7 @@ func (a *autoScalingGroup) havingReadyToAttachSpotInstance() (*string, bool) {
 				} else {
 					logger.Println(a.name, "Active bid was found, with no running "+
 						"instances, waiting for an instance to start ...")
-					req.waitForAndTagSpotInstance()
+					req.waitForSpotInstance()
 					activeSpotInstanceRequest = req
 				}
 			}
@@ -574,34 +574,28 @@ func (a *autoScalingGroup) bidForSpotInstance(
 		return err
 	}
 
+	// Fetching all required tags prior to launching the SpotRequest
 	spotRequest := resp.SpotInstanceRequests[0]
-	sr := spotInstanceRequest{SpotInstanceRequest: spotRequest,
-		region: a.region,
-		asg:    a,
+	spotRequest.Tags = a.propagatedInstanceTags()
+	spotRequest.Tags = append(spotRequest.Tags, &ec2.Tag{
+		Key:   aws.String("launched-for-asg"),
+		Value: aws.String(a.name),
+	})
+	sr := spotInstanceRequest{
+		SpotInstanceRequest: spotRequest,
+		region:              a.region,
+		asg:                 a,
 	}
 
 	srID := sr.SpotInstanceRequestId
 
 	logger.Println(a.name, "Created spot instance request", *srID)
 
-	// tag the spot instance request to associate it with the current ASG, so we
-	// know where to attach the instance later. In case the waiter failed, it may
-	// happen that the instance is actually tagged in the next run, but the spot
-	// instance request needs to be tagged anyway.
-	err = sr.tag(a.name)
-
-	if err != nil {
-		logger.Println(a.name, "Can't tag spot instance request", err.Error())
-		return err
-	}
-	// Waiting for the instance to start so that we can then later tag it with
-	// the same tags originally set on the on-demand instances.
-	//
 	// This waiter only returns after the instance was found and it may be
 	// interrupted by the lambda function's timeout, so we also need to check in
 	// the next run if we have any open spot requests with no instances and
 	// resume the wait there.
-	return sr.waitForAndTagSpotInstance()
+	return sr.waitForSpotInstance()
 }
 
 func (a *autoScalingGroup) setAutoScalingMaxSize(maxSize int64) error {

--- a/core/instance.go
+++ b/core/instance.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/davecgh/go-spew/spew"
@@ -242,42 +241,6 @@ func (i *instance) getCheapestCompatibleSpotInstanceType() (string, error) {
 		return chosenSpotType, nil
 	}
 	return chosenSpotType, fmt.Errorf("No cheaper spot instance types could be found")
-}
-
-func (i *instance) tag(tags []*ec2.Tag, maxIter int, sleepFunc func(d time.Duration)) error {
-	var (
-		n   int
-		err error
-	)
-
-	if len(tags) == 0 {
-		logger.Println(i.region.name, "Tagging spot instance", *i.InstanceId,
-			"no tags were defined, skipping...")
-		return nil
-	}
-
-	svc := i.region.services.ec2
-	params := ec2.CreateTagsInput{
-		Resources: []*string{i.InstanceId},
-		Tags:      tags,
-	}
-
-	logger.Println(i.region.name, "Tagging spot instance", *i.InstanceId)
-
-	for n = 0; n < maxIter; n++ {
-		_, err = svc.CreateTags(&params)
-		if err == nil {
-			logger.Println("Instance", *i.InstanceId,
-				"was tagged with the following tags:", tags)
-			break
-		}
-		logger.Println(i.region.name,
-			"Failed to create tags for the spot instance", *i.InstanceId, err.Error())
-		logger.Println(i.region.name,
-			"Sleeping for 5 seconds before retrying")
-		sleepFunc(5 * time.Second)
-	}
-	return err
 }
 
 // Why the heck isn't this in the Go standard library?

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -902,104 +901,6 @@ func TestTerminate(t *testing.T) {
 		if ret != nil && ret.Error() != tt.expected.Error() {
 			t.Errorf("error actual: %s, expected: %s", ret.Error(), tt.expected.Error())
 		}
-	}
-}
-
-// Ideally should find a better way to test tagging
-// and avoid having a small wait of 1 timeout
-func TestTag(t *testing.T) {
-
-	tests := []struct {
-		name          string
-		tags          []*ec2.Tag
-		inst          *instance
-		expectedError error
-	}{
-		{
-			name: "no tags without error",
-			tags: []*ec2.Tag{},
-			inst: &instance{
-				Instance: &ec2.Instance{
-					InstanceId: aws.String("id1"),
-				},
-				region: &region{
-					name: "test",
-					services: connections{
-						ec2: mockEC2{
-							cterr: nil,
-						},
-					},
-				},
-			},
-			expectedError: nil,
-		},
-		{
-			name: "no tags with error",
-			tags: []*ec2.Tag{},
-			inst: &instance{
-				Instance: &ec2.Instance{
-					InstanceId: aws.String("id1"),
-				},
-				region: &region{
-					name: "test",
-					services: connections{
-						ec2: mockEC2{
-							cterr: errors.New("no tags with error"),
-						},
-					},
-				},
-			},
-			expectedError: errors.New("no tags with error"),
-		},
-		{
-			name: "tags without error",
-			tags: []*ec2.Tag{
-				{Key: aws.String("proj"), Value: aws.String("test")},
-				{Key: aws.String("x"), Value: aws.String("3")},
-			},
-			inst: &instance{
-				Instance: &ec2.Instance{
-					InstanceId: aws.String("id1"),
-				},
-				region: &region{
-					name: "test",
-					services: connections{
-						ec2: mockEC2{
-							cterr: nil,
-						},
-					},
-				},
-			},
-			expectedError: nil,
-		},
-		{
-			name: "tags with error",
-			tags: []*ec2.Tag{
-				{Key: aws.String("proj"), Value: aws.String("test")},
-				{Key: aws.String("x"), Value: aws.String("3")},
-			},
-			inst: &instance{
-				Instance: &ec2.Instance{
-					InstanceId: aws.String("id1"),
-				},
-				region: &region{
-					name: "test",
-					services: connections{
-						ec2: mockEC2{
-							cterr: errors.New("tags with error"),
-						},
-					},
-				},
-			},
-			expectedError: errors.New("tags with error"),
-		},
-	}
-
-	mockedSleep := func(time.Duration) {}
-
-	for _, tt := range tests {
-		err := tt.inst.tag(tt.tags, 1, mockedSleep)
-		CheckErrors(t, err, tt.expectedError)
 	}
 }
 

--- a/core/spot_instance_request.go
+++ b/core/spot_instance_request.go
@@ -1,8 +1,6 @@
 package autospotting
 
 import (
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -19,7 +17,7 @@ type spotInstanceRequest struct {
 }
 
 // This function returns an Instance ID
-func (s *spotInstanceRequest) waitForAndTagSpotInstance() error {
+func (s *spotInstanceRequest) waitForSpotInstance() error {
 	logger.Println(s.asg.name, "Waiting for spot instance for spot instance request",
 		*s.SpotInstanceRequestId)
 
@@ -33,37 +31,6 @@ func (s *spotInstanceRequest) waitForAndTagSpotInstance() error {
 	if err != nil {
 		logger.Println(s.asg.name, "Error waiting for instance:", err.Error())
 		return err
-	}
-
-	logger.Println(s.asg.name, "Done waiting for an instance.")
-
-	// Now we try to get the InstanceID of the instance we got
-	requestDetails, err := ec2Client.DescribeSpotInstanceRequests(&params)
-	if err != nil {
-		logger.Println(s.asg.name, "Failed to describe spot instance requests")
-		return err
-	}
-
-	// due to the waiter we can now safely assume all this data is available
-	spotInstanceID := requestDetails.SpotInstanceRequests[0].InstanceId
-
-	logger.Println(s.asg.name, "Found new spot instance", *spotInstanceID)
-	logger.Println("Tagging it to match the other instances from the group")
-
-	// we need to re-scan in order to have the information a
-	err = s.region.scanInstances()
-	if err != nil {
-		logger.Printf("Failed to scan instances: %s for %s\n", err, s.asg.name)
-	}
-
-	tags := s.asg.propagatedInstanceTags()
-
-	i := s.region.instances.get(*spotInstanceID)
-
-	if i != nil {
-		i.tag(tags, defaultTimeout, time.Sleep)
-	} else {
-		logger.Println(s.asg.name, "new spot instance", *spotInstanceID, "has disappeared")
 	}
 	return nil
 }

--- a/core/spot_instance_request_test.go
+++ b/core/spot_instance_request_test.go
@@ -89,7 +89,7 @@ func Test_waitForAndTagSpotInstance(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc.req.waitForAndTagSpotInstance()
+		tc.req.waitForSpotInstance()
 	}
 }
 


### PR DESCRIPTION
# Bugfix Pull Request #

## Summary ##

The previous way of tagging the spot instances, was to create it, then
wait to add the various tags (those of the ASG), and the name of the ASG
to know where to attach it. However, all of this information is supposed
to be already known, so the tagging has been delegated to the AWS API.

**Important**: I'm aware that the code is currently untested, and hasn't been manually tested either - only the logic has been reviewed. Tests should follow once the logic & code have been validated working as expected. Nevertheless it does compile and passes tests as such.

Hopefully that work will fix: https://github.com/cristim/autospotting/issues/111 & https://github.com/cristim/autospotting/issues/20