### PR TITLE
In progress: Enable EBS pricing and automatically turn on if free

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -543,7 +543,7 @@ func (a *autoScalingGroup) launchCheapestSpotInstance(azToLaunchIn *string) erro
 
 	spotLS := lc.convertLaunchConfigurationToSpotSpecification(
 		baseInstance,
-		&newInstance,
+		newInstance,
 		*azToLaunchIn)
 
 	logger.Println("Bidding for spot instance for ", a.name)

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -527,10 +527,11 @@ func (a *autoScalingGroup) launchCheapestSpotInstance(azToLaunchIn *string) erro
 		return errors.New("no cheaper spot instance found")
 	}
 
+	newInstance := a.region.instanceTypeInformation[newInstanceType]
+
 	baseOnDemandPrice := baseInstance.price
 
-	currentSpotPrice := a.region.
-		instanceTypeInformation[newInstanceType].pricing.spot[*azToLaunchIn]
+	currentSpotPrice := newInstance.pricing.spot[*azToLaunchIn]
 
 	logger.Println("Finished searching for best spot instance in ", *azToLaunchIn)
 	logger.Println("Replacing an on-demand", *baseInstance.InstanceType,
@@ -542,7 +543,7 @@ func (a *autoScalingGroup) launchCheapestSpotInstance(azToLaunchIn *string) erro
 
 	spotLS := lc.convertLaunchConfigurationToSpotSpecification(
 		baseInstance,
-		newInstanceType,
+		&newInstance,
 		*azToLaunchIn)
 
 	logger.Println("Bidding for spot instance for ", a.name)

--- a/core/instance.go
+++ b/core/instance.go
@@ -242,15 +242,15 @@ func (i *instance) getCheapestCompatibleSpotInstanceType() (string, error) {
 		logger.Println("Comparing ", candidate.instanceType, " with ",
 			current.instanceType)
 
-		currentPrice := i.calculatePrice(candidate)
+		candidatePrice := i.calculatePrice(candidate)
 
 		if i.isSpotQuantityCompatible(candidate) &&
-			i.isPriceCompatible(currentPrice, bestPrice) &&
+			i.isPriceCompatible(candidatePrice, bestPrice) &&
 			i.isEBSCompatible(candidate) &&
 			i.isClassCompatible(candidate) &&
 			i.isStorageCompatible(candidate, attachedVolumesNumber) &&
 			i.isVirtualizationCompatible(candidate.virtualizationTypes) {
-			bestPrice = currentPrice
+			bestPrice = candidatePrice
 			chosenSpotType = candidate.instanceType
 			debug.Println("Best option is now: ", chosenSpotType, " at ", bestPrice)
 		} else if chosenSpotType != "" {

--- a/core/instance.go
+++ b/core/instance.go
@@ -166,6 +166,13 @@ func (i *instance) isClassCompatible(spotCandidate instanceTypeInformation) bool
 	return spotCandidate.vCPU >= current.vCPU && spotCandidate.memory >= current.memory
 }
 
+func (i *instance) isEBSCompatible(spotCandidate instanceTypeInformation) bool {
+	if i.EbsOptimized != nil && *i.EbsOptimized && !spotCandidate.hasEBSOptimization {
+		return false
+	}
+	return true
+}
+
 // Here we check the storage compatibility, with the following evaluation
 // criteria:
 // - speed: don't accept spinning disks when we used to have SSDs
@@ -233,6 +240,7 @@ func (i *instance) getCheapestCompatibleSpotInstanceType() (string, error) {
 
 		if i.isSpotQuantityCompatible(candidate) &&
 			i.isPriceCompatible(candidate, bestPrice) &&
+			i.isEBSCompatible(candidate) &&
 			i.isClassCompatible(candidate) &&
 			i.isStorageCompatible(candidate, attachedVolumesNumber) &&
 			i.isVirtualizationCompatible(candidate.virtualizationTypes) {

--- a/core/instance.go
+++ b/core/instance.go
@@ -237,6 +237,9 @@ func (i *instance) getCheapestCompatibleSpotInstanceType() (string, error) {
 			i.isStorageCompatible(candidate, attachedVolumesNumber) &&
 			i.isVirtualizationCompatible(candidate.virtualizationTypes) {
 			bestPrice = candidate.pricing.spot[*i.Placement.AvailabilityZone]
+			if i.EbsOptimized != nil && *i.EbsOptimized {
+				bestPrice += candidate.pricing.ebsSurcharge
+			}
 			chosenSpotType = candidate.instanceType
 			debug.Println("Best option is now: ", chosenSpotType, " at ", bestPrice)
 		} else if chosenSpotType != "" {

--- a/core/instance.go
+++ b/core/instance.go
@@ -144,12 +144,13 @@ func (i *instance) isSpotQuantityCompatible(spotCandidate instanceTypeInformatio
 
 func (i *instance) isPriceCompatible(spotCandidate instanceTypeInformation, bestPrice float64) bool {
 	spotPrice := spotCandidate.pricing.spot[*i.Placement.AvailabilityZone]
+	debug.Println("Comparing price spot/instance:")
 
-	if i.EbsOptimized != nil {
+	if i.EbsOptimized != nil && *i.EbsOptimized {
 		spotPrice += spotCandidate.pricing.ebsSurcharge
+		debug.Println("\tEBS Surcharge : ", spotCandidate.pricing.ebsSurcharge)
 	}
 
-	debug.Println("Comparing price spot/instance:")
 	debug.Println("\tSpot price: ", spotPrice)
 	debug.Println("\tInstance price: ", i.price)
 	return spotPrice != 0 && spotPrice <= i.price && spotPrice <= bestPrice

--- a/core/instance.go
+++ b/core/instance.go
@@ -145,7 +145,7 @@ func (i *instance) isSpotQuantityCompatible(spotCandidate instanceTypeInformatio
 func (i *instance) isPriceCompatible(spotCandidate instanceTypeInformation, bestPrice float64) bool {
 	spotPrice := spotCandidate.pricing.spot[*i.Placement.AvailabilityZone]
 
-	if *i.EbsOptimized {
+	if i.EbsOptimized != nil {
 		spotPrice += spotCandidate.pricing.ebsSurcharge
 	}
 

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -234,6 +234,69 @@ func TestIsSpot(t *testing.T) {
 		})
 	}
 }
+func TestIsEBSCompatible(t *testing.T) {
+	tests := []struct {
+		name         string
+		spotInfo     instanceTypeInformation
+		instanceInfo instance
+		expected     bool
+	}{
+		{name: "EBS not Optimized Spot not Optimized",
+			spotInfo: instanceTypeInformation{
+				hasEBSOptimization: false,
+			},
+			instanceInfo: instance{
+				Instance: &ec2.Instance{
+					EbsOptimized: nil,
+				},
+			},
+			expected: true,
+		},
+		{name: "EBS Optimized Spot Optimized",
+			spotInfo: instanceTypeInformation{
+				hasEBSOptimization: true,
+			},
+			instanceInfo: instance{
+				Instance: &ec2.Instance{
+					EbsOptimized: &[]bool{true}[0],
+				},
+			},
+			expected: true,
+		},
+		{name: "EBS Optimized Spot not Optimized",
+			spotInfo: instanceTypeInformation{
+				hasEBSOptimization: false,
+			},
+			instanceInfo: instance{
+				Instance: &ec2.Instance{
+					EbsOptimized: &[]bool{true}[0],
+				},
+			},
+			expected: false,
+		},
+		{name: "EBS not Optimized Spot Optimized",
+			spotInfo: instanceTypeInformation{
+				hasEBSOptimization: true,
+			},
+			instanceInfo: instance{
+				Instance: &ec2.Instance{
+					EbsOptimized: &[]bool{false}[0],
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &tt.instanceInfo
+			retValue := i.isEBSCompatible(tt.spotInfo)
+			if retValue != tt.expected {
+				t.Errorf("Value received: %t expected %t", retValue, tt.expected)
+			}
+		})
+	}
+}
 
 func TestIsPriceCompatible(t *testing.T) {
 	tests := []struct {

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -321,7 +321,8 @@ func TestIsPriceCompatible(t *testing.T) {
 			}
 			candidate := instanceTypeInformation{pricing: prices{}}
 			candidate.pricing = tt.spotPrices
-			retValue, _ := i.isPriceCompatible(candidate, tt.bestPrice)
+			spotPrice := i.calculatePrice(candidate)
+			retValue := i.isPriceCompatible(spotPrice, tt.bestPrice)
 			if retValue != tt.expected {
 				t.Errorf("Value received: %t expected %t", retValue, tt.expected)
 			}

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -321,7 +321,7 @@ func TestIsPriceCompatible(t *testing.T) {
 			}
 			candidate := instanceTypeInformation{pricing: prices{}}
 			candidate.pricing = tt.spotPrices
-			retValue := i.isPriceCompatible(candidate, tt.bestPrice)
+			retValue, _ := i.isPriceCompatible(candidate, tt.bestPrice)
 			if retValue != tt.expected {
 				t.Errorf("Value received: %t expected %t", retValue, tt.expected)
 			}

--- a/core/launch_configuration.go
+++ b/core/launch_configuration.go
@@ -35,7 +35,7 @@ func (lc *launchConfiguration) countLaunchConfigEphemeralVolumes() int {
 
 func (lc *launchConfiguration) convertLaunchConfigurationToSpotSpecification(
 	baseInstance *instance,
-	newInstance *instanceTypeInformation,
+	newInstance instanceTypeInformation,
 	az string) *ec2.RequestSpotLaunchSpecification {
 
 	var spotLS ec2.RequestSpotLaunchSpecification
@@ -47,8 +47,7 @@ func (lc *launchConfiguration) convertLaunchConfigurationToSpotSpecification(
 		spotLS.EbsOptimized = lc.EbsOptimized
 	}
 
-	if *lc.EbsOptimized == false && newInstance.hasEBSOptimization && newInstance.pricing.ebsSurcharge == 0.0 {
-		logger.Println("EBS Optimization is free for this instance type turning on...")
+	if newInstance.hasEBSOptimization && newInstance.pricing.ebsSurcharge == 0.0 {
 		spotLS.SetEbsOptimized(true)
 	}
 

--- a/core/region.go
+++ b/core/region.go
@@ -30,8 +30,9 @@ type region struct {
 }
 
 type prices struct {
-	onDemand float64
-	spot     spotPriceMap
+	onDemand     float64
+	spot         spotPriceMap
+	ebsSurcharge float64
 }
 
 // The key in this map is the availavility zone
@@ -159,8 +160,8 @@ func (r *region) determineInstanceTypeInformation(cfg Config) {
 
 		// populate on-demand information
 		price.onDemand = it.Pricing[r.name].Linux.OnDemand
-
 		price.spot = make(spotPriceMap)
+		price.ebsSurcharge = it.Pricing[r.name].EBSSurcharge
 
 		// if at this point the instance price is still zero, then that
 		// particular instance type doesn't even exist in the current
@@ -174,6 +175,7 @@ func (r *region) determineInstanceTypeInformation(cfg Config) {
 				memory:              it.Memory,
 				pricing:             price,
 				virtualizationTypes: it.LinuxVirtualizationTypes,
+				hasEBSOptimization:  it.EBSOptimized,
 			}
 
 			if it.Storage != nil {

--- a/core/region.go
+++ b/core/region.go
@@ -205,7 +205,7 @@ func (r *region) requestSpotPrices() error {
 
 	// Retrieve all current spot prices from the current region.
 	// TODO: add support for other OSes
-	err := s.fetch("Linux/UNIX (Amazon VPC)", 0, nil, nil)
+	err := s.fetch("Linux/UNIX", 0, nil, nil)
 
 	if err != nil {
 		return errors.New("Couldn't fetch spot prices in" + r.name)

--- a/core/region.go
+++ b/core/region.go
@@ -205,7 +205,7 @@ func (r *region) requestSpotPrices() error {
 
 	// Retrieve all current spot prices from the current region.
 	// TODO: add support for other OSes
-	err := s.fetch("Linux/UNIX", 0, nil, nil)
+	err := s.fetch("Linux/UNIX (Amazon VPC)", 0, nil, nil)
 
 	if err != nil {
 		return errors.New("Couldn't fetch spot prices in" + r.name)


### PR DESCRIPTION
# Issue Type #

<!-- Pick one below and delete the others: -->

- Feature Pull Request
- Bug fix
## Summary ##
- Include EBS surcharging in price calculation. 
- Turn on EBS optimization if it is free. ( Implements #88 )
- Fix bug where launch config has EBS enabled but Autospotting selects an instance which does not have the capability. ( Fixes #115 )

<!-- Describe the change, including rationale and design decisions -->

<!--
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text
```
