### PR TITLE
Propagate GPU count into the instance type information

### DIFF
--- a/core/region.go
+++ b/core/region.go
@@ -173,6 +173,7 @@ func (r *region) determineInstanceTypeInformation(cfg *Config) {
 				instanceType:        it.InstanceType,
 				vCPU:                it.VCPU,
 				memory:              it.Memory,
+				GPU:                 it.GPU,
 				pricing:             price,
 				virtualizationTypes: it.LinuxVirtualizationTypes,
 				hasEBSOptimization:  it.EBSOptimized,


### PR DESCRIPTION

# Issue Type

- Bugfix Pull Request

## Summary

This should hopefully fix #126, but needs to be confirmed by someone who
can afford to run such expensive instances :-)

## Code contribution checklist

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] (N/A) Functionality not applicable to all users should be configurable.
1. [x] (N/A) Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [x] (N/A) Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] (N/A) Tags names and expected values should be similar to the other existing
   configurations.
1. [x] (N/A) The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
