### PR TITLE
Use Go 1.9 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.8
+- 1.9
 
 sudo: required
 


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

Update TravisCI builds to the latest golang version, 1.9