### PR TITLE
use TerminateInstanceInAutoScalingGroup instead of Detach

### DIFF
--- a/cloudformation/stacks/AutoSpotting/template.json
+++ b/cloudformation/stacks/AutoSpotting/template.json
@@ -97,7 +97,7 @@
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeLaunchConfigurations",
                 "autoscaling:AttachInstances",
-                "autoscaling:DetachInstances",
+                "autoscaling:TerminateInstanceInAutoScalingGroup",
                 "autoscaling:DescribeTags",
                 "autoscaling:UpdateAutoScalingGroup",
                 "ec2:CreateTags",

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -101,9 +101,9 @@ func (m mockEC2) DescribeRegions(*ec2.DescribeRegionsInput) (*ec2.DescribeRegion
 // This is useful when methods are doing multiple calls to AWS API
 type mockASG struct {
 	autoscalingiface.AutoScalingAPI
-	// Detach Instances
-	dio   *autoscaling.DetachInstancesOutput
-	dierr error
+	// Terminate Instances
+	tiiasgo   *autoscaling.TerminateInstanceInAutoScalingGroupOutput
+	tiiasgerr error
 	// Attach Instances
 	aio   *autoscaling.AttachInstancesOutput
 	aierr error
@@ -118,8 +118,8 @@ type mockASG struct {
 	dterr error
 }
 
-func (m mockASG) DetachInstances(*autoscaling.DetachInstancesInput) (*autoscaling.DetachInstancesOutput, error) {
-	return m.dio, m.dierr
+func (m mockASG) TerminateInstanceInAutoScalingGroup(*autoscaling.TerminateInstanceInAutoScalingGroupInput) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error) {
+	return m.tiiasgo, m.tiiasgerr
 }
 
 func (m mockASG) AttachInstances(*autoscaling.AttachInstancesInput) (*autoscaling.AttachInstancesOutput, error) {

--- a/terraform/autospotting/autospotting-policy.json
+++ b/terraform/autospotting/autospotting-policy.json
@@ -6,7 +6,7 @@
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:AttachInstances",
-        "autoscaling:DetachInstances",
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:DescribeTags",
         "autoscaling:UpdateAutoScalingGroup",
         "ec2:CreateTags",


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

Fixes #138

## Code contribution checklist

1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
