### PR TITLE
minor refactor: Refer to argument in isExpired 

### DIFF
--- a/expiration.go
+++ b/expiration.go
@@ -5,6 +5,6 @@ import "time"
 const dateFormat = "02-Jan-2006"
 
 func isExpired(date string) bool {
-	exp, _ := time.Parse(dateFormat, ExpirationDate)
+	exp, _ := time.Parse(dateFormat, date)
 	return time.Now().After(exp)
 }


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request

## Summary

Was going through the code and found that though `isExpired` was been called with `ExpirationDate`, the method was still referring to `main.ExpirationDate`. 
It's a small change but more intuitive while going through the code.

## Code contribution checklist
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
