### PR TITLE
add new global option on_demand_price_multiplier to support volume discounts

### DIFF
--- a/START.md
+++ b/START.md
@@ -217,9 +217,10 @@ Usage of ./autospotting:
         Can be overridden on a per-group basis using the tag autospotting_on_demand_percentage
         It is ignored if min_on_demand_number is also set.
   -on_demand_price_multiplier float
-        Multiplier for the on-demand price. This is useful for volume discounts or if you want
-        to set your bid price to be higher than the on demand price to reduce the chances that
-        your spot instances will be terminated. (default 1)
+        Multiplier for the on-demand price. This is useful for volume discounts
+        or if you want to set your bid price to be higher than the on demand
+        price to reduce the chances that your spot instances will be terminated.
+        (default 1)
   -regions="": Regions where it should be activated (comma or whitespace separated
         list, also supports globs), by default it runs on all regions.
         Example: ./autospotting -regions 'eu-*,us-east-1'

--- a/START.md
+++ b/START.md
@@ -217,9 +217,9 @@ Usage of ./autospotting:
         Can be overridden on a per-group basis using the tag autospotting_on_demand_percentage
         It is ignored if min_on_demand_number is also set.
   -on_demand_price_multiplier float
-	Multiplier for the on-demand price. This is useful for volume discounts or if you want to
-	set your bid price to be higher than the on demand price to reduce the chances that your
-	spot instances will be terminated. (default 1)
+        Multiplier for the on-demand price. This is useful for volume discounts or if you want
+        to set your bid price to be higher than the on demand price to reduce the chances that
+        your spot instances will be terminated. (default 1)
   -regions="": Regions where it should be activated (comma or whitespace separated
         list, also supports globs), by default it runs on all regions.
         Example: ./autospotting -regions 'eu-*,us-east-1'

--- a/START.md
+++ b/START.md
@@ -114,6 +114,7 @@ module "autospotting" {
   autospotting_min_on_demand_number = "0"
   autospotting_min_on_demand_percentage = "50.0"
   autospotting_regions_enabled = "eu*,us*"
+  on_demand_price_multiplier = "1.0"
 
   lambda_zipname = "./lambda.zip"
   lambda_runtime = "python2.7"
@@ -215,6 +216,10 @@ Usage of ./autospotting:
         of instances in the group) ensured to be running in each of your groups.
         Can be overridden on a per-group basis using the tag autospotting_on_demand_percentage
         It is ignored if min_on_demand_number is also set.
+  -on_demand_price_multiplier float
+	Multiplier for the on-demand price. This is useful for volume discounts or if you want to
+	set your bid price to be higher than the on demand price to reduce the chances that your
+	spot instances will be terminated. (default 1)
   -regions="": Regions where it should be activated (comma or whitespace separated
         list, also supports globs), by default it runs on all regions.
         Example: ./autospotting -regions 'eu-*,us-east-1'

--- a/autospotting.go
+++ b/autospotting.go
@@ -39,11 +39,13 @@ func run() {
 		"regions='%s' "+
 		"min_on_demand_number=%d "+
 		"min_on_demand_percentage=%.1f "+
-		"allowed_instance_types=%v",
+		"allowed_instance_types=%v "+
+		"on_demand_price_multiplier=%.2f",
 		conf.Regions,
 		conf.MinOnDemandNumber,
 		conf.MinOnDemandPercentage,
-		conf.AllowedInstanceTypes)
+		conf.AllowedInstanceTypes,
+		conf.OnDemandPriceMultiplier)
 
 	autospotting.Run(conf.Config)
 	log.Println("Execution completed, nothing left to do")
@@ -114,6 +116,12 @@ func (c *cfgData) parseCommandLineFlags() {
 		"If specified, the spot instances will have a specific instance type:\n"+
 			"\tcurrent: the same as initial on-demand instances\n"+
 			"\t<instance-type>: the actual instance type to use")
+
+	flag.Float64Var(&c.OnDemandPriceMultiplier, "on_demand_price_multiplier", 1.0,
+		"Multiplier for the on-demand price. This is useful for volume discounts or if you want to\n"+
+			"\tset your bid price to be higher than the on demand price to reduce the chances that your\n"+
+			"\tspot instances will be terminated.")
+
 	v := flag.Bool("version", false, "Print version number and exit.")
 
 	flag.Parse()

--- a/cloudformation/stacks/AutoSpotting/template.json
+++ b/cloudformation/stacks/AutoSpotting/template.json
@@ -42,6 +42,11 @@
       "Description": "Minimum on-demand instances (percentage of the instances currently running in each group) that will be kept when replacing with spot instances. It is also a global default value that can be overridden on a per-group basis using the autospotting_on_demand_percentage tag. MinOnDemandNumber takes precedence if both these parameters are passed",
       "Type": "Number"
     },
+    "OnDemandPriceMultiplier": {
+      "Default": "1.0",
+      "Description": "Multiplier for the on-demand price. This is useful for volume discounts or if you want to set your bid price to be higher than the on demand price to reduce the chances that your spot instances will be terminated.",
+      "Type": "Number"
+    },
     "Regions": {
       "Default": "",
       "Description": "Space separated list of regions where it should run (supports globs), in case you may want to limit it to a smaller set of regions. If unset it will run against all available regions. Example: 'us-east-1 eu-*'",
@@ -77,6 +82,7 @@
           "Variables": {
             "MIN_ON_DEMAND_NUMBER": { "Ref": "MinOnDemandNumber" },
             "MIN_ON_DEMAND_PERCENTAGE": { "Ref": "MinOnDemandPercentage" },
+            "ON_DEMAND_PRICE_MULTIPLIER": { "Ref": "OnDemandPriceMultiplier" },
             "REGIONS": { "Ref": "Regions" }
           }
         },

--- a/core/config.go
+++ b/core/config.go
@@ -21,10 +21,11 @@ type Config struct {
 	// The region where the Lambda function is deployed
 	MainRegion string
 
-	MinOnDemandNumber     int64
-	MinOnDemandPercentage float64
-	Regions               string
-	AllowedInstanceTypes  string
+	MinOnDemandNumber       int64
+	MinOnDemandPercentage   float64
+	Regions                 string
+	AllowedInstanceTypes    string
+	OnDemandPriceMultiplier float64
 
 	// This is only here for tests, where we want to be able to somehow mock
 	// time.Sleep without actually sleeping. While testing it defaults to 0 (which won't sleep at all), in

--- a/core/region.go
+++ b/core/region.go
@@ -159,7 +159,7 @@ func (r *region) determineInstanceTypeInformation(cfg *Config) {
 		debug.Println(it)
 
 		// populate on-demand information
-		price.onDemand = it.Pricing[r.name].Linux.OnDemand
+		price.onDemand = it.Pricing[r.name].Linux.OnDemand * cfg.OnDemandPriceMultiplier
 		price.spot = make(spotPriceMap)
 		price.ebsSurcharge = it.Pricing[r.name].EBSSurcharge
 

--- a/terraform/autospotting.tf
+++ b/terraform/autospotting.tf
@@ -3,6 +3,7 @@ module "autospotting" {
 
   autospotting_min_on_demand_number = "${var.asg_min_on_demand_number}"
   autospotting_min_on_demand_percentage = "${var.asg_min_on_demand_percentage}"
+  autospotting_on_demand_price_multiplier = "${var.asg_on_demand_price_multiplier}"
   autospotting_regions_enabled = "${var.asg_regions_enabled}"
 
   lambda_zipname = "${var.lambda_zipname}"

--- a/terraform/autospotting/lambda.tf
+++ b/terraform/autospotting/lambda.tf
@@ -12,6 +12,7 @@ resource "aws_lambda_function" "autospotting" {
     variables = {
       MIN_ON_DEMAND_NUMBER = "${var.autospotting_min_on_demand_number}"
       MIN_ON_DEMAND_PERCENTAGE = "${var.autospotting_min_on_demand_percentage}"
+      ON_DEMAND_PRICE_MULTIPLIER = "${var.autospotting_on_demand_price_multiplier}"
       REGIONS = "${var.autospotting_regions_enabled}"
     }
   }

--- a/terraform/autospotting/variables.tf
+++ b/terraform/autospotting/variables.tf
@@ -7,6 +7,10 @@ variable "autospotting_min_on_demand_percentage" {
   description = "Minimum on-demand instances to keep in percentage"
 }
 
+variable "autospotting_on_demand_price_multiplier" {
+  description = "Multiplier for the on-demand price"
+}
+
 variable "autospotting_regions_enabled" {
   description = "Regions that autospotting is watching"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,6 +9,11 @@ variable "asg_min_on_demand_percentage" {
   default = "0.0"
 }
 
+variable "asg_on_demand_price_multiplier" {
+  description = "Multiplier for the on-demand price"
+  default = "1.0"
+}
+
 variable "asg_regions_enabled" {
   description = "Regions in which autospotting is enabled"
   default = ""


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

This patch adds a new global option called on_demand_price_multiplier that is primarily intended to be used to support EC2 volume discounts. The option could also be used to set your set your bid price to be higher than the on demand price to reduce the chances that your spot instances will be terminated.

Note: There are currently no tests associated with this change. I started to write some tests for region.determineInstanceTypeInformation(), however ec2instancesinfo.regionPrices is not exposed publicly. Before I started sending you other pull requests to make these changes I first wanted to see if you would accept a patch like this or if you would like this feature to be implemented in a different manner.