### PR TITLE
Added SpotInstance Percentage Multiplier with dynamic tags

### DIFF
--- a/START.md
+++ b/START.md
@@ -125,6 +125,8 @@ module "autospotting" {
   autospotting_min_on_demand_percentage = "50.0"
   autospotting_regions_enabled = "eu*,us*"
   on_demand_price_multiplier = "1.0"
+  spot_price_buffer_percentage = "10.0"
+  bidding_policy = "normal"
 
   lambda_zipname = "./lambda.zip"
   lambda_runtime = "python2.7"
@@ -224,6 +226,17 @@ Usage of ./autospotting:
         or if you want to set your bid price to be higher than the on demand
         price to reduce the chances that your spot instances will be terminated.
         (default 1)
+  -spot_price_buffer_percentage float
+        Percentage Value of the bid above the current spot price. A spot
+        bid would be placed at a value
+        current_spot_price * [1 + (spot_price_buffer_percentage/100.0)] .
+        The main benefit is that it protects the group from running spot instances
+        that got significantly more expensive than when they were initially launched,
+        but still somewhat less than the on-demand price. (default 10.0)
+  -bidding_policy string
+        Policy choice for spot bid. If set to 'normal', we bid at the
+        on-demand price. If set to 'aggressive', we bid at a multiple of
+        the spot price. (default "normal")
   -regions="": Regions where it should be activated (comma or whitespace separated
         list, also supports globs), by default it runs on all regions.
         Example: ./autospotting -regions 'eu-*,us-east-1'

--- a/autospotting.go
+++ b/autospotting.go
@@ -42,12 +42,16 @@ func run() {
 		"min_on_demand_number=%d "+
 		"min_on_demand_percentage=%.1f "+
 		"allowed_instance_types=%v "+
-		"on_demand_price_multiplier=%.2f",
+		"on_demand_price_multiplier=%.2f"+
+		"spot_price_buffer_percentage=%.3f"+
+		"bidding_policy=%s",
 		conf.Regions,
 		conf.MinOnDemandNumber,
 		conf.MinOnDemandPercentage,
 		conf.AllowedInstanceTypes,
-		conf.OnDemandPriceMultiplier)
+		conf.OnDemandPriceMultiplier,
+		conf.SpotPriceBufferPercentage,
+		conf.BiddingPolicy)
 
 	autospotting.Run(conf.Config)
 	log.Println("Execution completed, nothing left to do")
@@ -123,6 +127,18 @@ func (c *cfgData) parseCommandLineFlags() {
 		"Multiplier for the on-demand price. This is useful for volume discounts or if you want to\n"+
 			"\tset your bid price to be higher than the on demand price to reduce the chances that your\n"+
 			"\tspot instances will be terminated.")
+
+	flag.Float64Var(&c.SpotPriceBufferPercentage, "spot_price_buffer_percentage", 10,
+		"Percentage Value of the bid above the current spot price. A spot bid would be placed at a value :\n"+
+			"\tcurrent_spot_price * [1 + (spot_price_buffer_percentage/100.0)]. The main benefit is that\n"+
+			"\tit protects the group from running spot instances that got significantly more expensive than\n"+
+			"\twhen they were initially launched, but still somewhat less than the on-demand price. Can be\n"+
+			"\tenforced using the tag: "+autospotting.SpotPriceBufferPercentageTag+". If the bid exceeds\n"+
+			"\tthe on-demand price, we place a bid at on-demand price itself.")
+
+	flag.StringVar(&c.BiddingPolicy, "bidding_policy", "normal",
+		"Policy choice for spot bid. If set to 'normal', we bid at the on-demand price. If set to 'aggressive',\n"+
+			"\twe bid at a percentage value above the spot price. ")
 
 	v := flag.Bool("version", false, "Print version number and exit.")
 

--- a/cloudformation/stacks/AutoSpotting/template.json
+++ b/cloudformation/stacks/AutoSpotting/template.json
@@ -47,6 +47,16 @@
       "Description": "Multiplier for the on-demand price. This is useful for volume discounts or if you want to set your bid price to be higher than the on demand price to reduce the chances that your spot instances will be terminated.",
       "Type": "Number"
     },
+    "SpotPricePercentageBuffer": {
+      "Default": "10.0",
+      "Description": "Percentage Value of the bid above the current spot price. A spot bid would be placed at a value = current_spot_price * [1 + (spot_price_buffer_percentage/100.0)]. The main benefit is that it protects the group from running spot instances that got significantly more expensive than when they were initially launched, but still somewhat less than the on-demand price.",
+      "Type": "Number"
+    },
+    "BiddingPolicy": {
+      "Default": "normal",
+      "Description": "Policy choice for spot bid. If set to 'normal', we bid at the on-demand price. If set to 'aggressive', we bid at a multiple of the spot price.",
+      "Type": "String"
+    },
     "Regions": {
       "Default": "",
       "Description": "Space separated list of regions where it should run (supports globs), in case you may want to limit it to a smaller set of regions. If unset it will run against all available regions. Example: 'us-east-1 eu-*'",
@@ -88,6 +98,8 @@
             "MIN_ON_DEMAND_NUMBER": { "Ref": "MinOnDemandNumber" },
             "MIN_ON_DEMAND_PERCENTAGE": { "Ref": "MinOnDemandPercentage" },
             "ON_DEMAND_PRICE_MULTIPLIER": { "Ref": "OnDemandPriceMultiplier" },
+            "SPOT_PRICE_BUFFER_PERCENTAGE": { "Ref": "SpotPricePercentageBuffer"},
+            "BIDDING_POLICY": { "Ref": "BiddingPolicy"},
             "REGIONS": { "Ref": "Regions" },
             "ALLOWED_INSTANCE_TYPES": { "Ref": "AllowedInstanceTypes" }
           }

--- a/core/config.go
+++ b/core/config.go
@@ -21,11 +21,13 @@ type Config struct {
 	// The region where the Lambda function is deployed
 	MainRegion string
 
-	MinOnDemandNumber       int64
-	MinOnDemandPercentage   float64
-	Regions                 string
-	AllowedInstanceTypes    string
-	OnDemandPriceMultiplier float64
+	MinOnDemandNumber         int64
+	MinOnDemandPercentage     float64
+	Regions                   string
+	AllowedInstanceTypes      string
+	OnDemandPriceMultiplier   float64
+	SpotPriceBufferPercentage float64
+	BiddingPolicy             string
 
 	// This is only here for tests, where we want to be able to somehow mock
 	// time.Sleep without actually sleeping. While testing it defaults to 0 (which won't sleep at all), in

--- a/terraform/autospotting.tf
+++ b/terraform/autospotting.tf
@@ -1,10 +1,12 @@
 module "autospotting" {
   source = "./autospotting"
 
-  autospotting_min_on_demand_number       = "${var.asg_min_on_demand_number}"
-  autospotting_min_on_demand_percentage   = "${var.asg_min_on_demand_percentage}"
-  autospotting_on_demand_price_multiplier = "${var.asg_on_demand_price_multiplier}"
-  autospotting_regions_enabled            = "${var.asg_regions_enabled}"
+  autospotting_min_on_demand_number         = "${var.asg_min_on_demand_number}"
+  autospotting_min_on_demand_percentage     = "${var.asg_min_on_demand_percentage}"
+  autospotting_on_demand_price_multiplier   = "${var.asg_on_demand_price_multiplier}"
+  autospotting_spot_price_buffer_percentage = "${var.asg_spot_price_buffer_percentage}"
+  autospotting_bidding_policy               = "${var.asg_bidding_policy}"
+  autospotting_regions_enabled              = "${var.asg_regions_enabled}"
 
   lambda_zipname       = "${var.lambda_zipname}"
   lambda_runtime       = "${var.lambda_runtime}"

--- a/terraform/autospotting/lambda.tf
+++ b/terraform/autospotting/lambda.tf
@@ -10,10 +10,12 @@ resource "aws_lambda_function" "autospotting" {
 
   environment {
     variables = {
-      MIN_ON_DEMAND_NUMBER       = "${var.autospotting_min_on_demand_number}"
-      MIN_ON_DEMAND_PERCENTAGE   = "${var.autospotting_min_on_demand_percentage}"
-      ON_DEMAND_PRICE_MULTIPLIER = "${var.autospotting_on_demand_price_multiplier}"
-      REGIONS                    = "${var.autospotting_regions_enabled}"
+      MIN_ON_DEMAND_NUMBER         = "${var.autospotting_min_on_demand_number}"
+      MIN_ON_DEMAND_PERCENTAGE     = "${var.autospotting_min_on_demand_percentage}"
+      ON_DEMAND_PRICE_MULTIPLIER   = "${var.autospotting_on_demand_price_multiplier}"
+      SPOT_PRICE_BUFFER_PERCENTAGE = "${var.autospotting_spot_price_buffer_percentage}"
+      BIDDING_POLICY               = "${var.autospotting_bidding_policy}"
+      REGIONS                      = "${var.autospotting_regions_enabled}"
     }
   }
 }

--- a/terraform/autospotting/variables.tf
+++ b/terraform/autospotting/variables.tf
@@ -11,6 +11,14 @@ variable "autospotting_on_demand_price_multiplier" {
   description = "Multiplier for the on-demand price"
 }
 
+variable "autospotting_spot_price_buffer_percentage" {
+  description = "Percentage above the current spot price to place the bid"
+}
+
+variable "autospotting_bidding_policy" {
+  description = "Bidding policy for the spot bid"
+}
+
 variable "autospotting_regions_enabled" {
   description = "Regions that autospotting is watching"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,6 +14,16 @@ variable "asg_on_demand_price_multiplier" {
   default     = "1.0"
 }
 
+variable "asg_spot_price_buffer_percentage" {
+  description = "Percentage above the current spot price to place the bid"
+  default     = "10.0"
+}
+
+variable "asg_bidding_policy" {
+  description = "Choice of bidding policy for the spot instance"
+  default     = "normal"
+}
+
 variable "asg_regions_enabled" {
   description = "Regions in which autospotting is enabled"
   default     = ""


### PR DESCRIPTION
# Issue Type

- Feature Pull Request, implements #119.

## Summary

Added configurable policy to place bids at a multiple of spot instance price or at on-demand price. Also added dynamic tag to enable this feature for an auto-scaling group.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

## Code contribution checklist

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [x] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
