### PR TITLE
Makefile: check_deps exits properly on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,8 @@ clean:                                                       ## Remove installed
 .PHONY: clean
 
 check_deps:                                                  ## Verify the system has all dependencies installed
-	@for DEP in $(shell echo "$(DEPS)"); do \
-		command -v "$$DEP" &>/dev/null \
-		|| (echo "Error: dependency '$$DEP' is absent" ; exit 1); \
+	@for DEP in "$(DEPS)"; do \
+		if ! command -v "$$DEP" >/dev/null ; then echo "Error: dependency '$$DEP' is absent" ; exit 1; fi; \
 	done
 	@echo "all dependencies satisifed: $(DEPS)"
 .PHONY: check_deps


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request

## Summary

Due to the one-line in the Makefile, the exit was done on a subprocess
instead of the Makefile itself. Removing the grouping by a standard
if/then fixed this issue.

Closes https://github.com/cristim/autospotting/issues/188

## Testing

On a fresh golang:1.9 container:

```bash
root@78bee51a11d0:/go/src/autospotting# make check_deps
Error: dependency 'golint' is absent
Makefile:28: recipe for target 'check_deps' failed
make: *** [check_deps] Error 1

root@78bee51a11d0:/go/src/autospotting#  go get -u github.com/golang/lint/golint
root@78bee51a11d0:/go/src/autospotting# make check_deps
all dependencies satisifed: wget git golint go
```

## Code contribution checklist

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] No issues are reported when running `make full-test`.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
