### PR TITLE
Account for empty virtualization types

### DIFF
--- a/core/instance.go
+++ b/core/instance.go
@@ -217,6 +217,12 @@ func (i *instance) isVirtualizationCompatible(spotVirtualizationTypes []string) 
 	debug.Println("\tSpot virtualization: ", spotVirtualizationTypes)
 	debug.Println("\tInstance virtualization: ", current)
 
+	// c5.* instances do not have virtualization types, in this case
+	// we ignore this check and allow it to proceed.
+	if len(spotVirtualizationTypes) == 0 {
+		return true
+	}
+
 	for _, avt := range spotVirtualizationTypes {
 		if (avt == "PV") && (current == "paravirtual") ||
 			(avt == "HVM") && (current == "hvm") {

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -629,6 +629,11 @@ func TestIsVirtualizationCompatible(t *testing.T) {
 			instanceVirtualizationType: aws.String("hvm"),
 			expected:                   false,
 		},
+		{name: "Spot's virtualization is empty",
+			spotVirtualizationTypes:    []string{},
+			instanceVirtualizationType: aws.String("hvm"),
+			expected:                   true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request

## Summary

Allows for blank spot instance virtualization types. This is the case for all `c5.*` instances.

Closes https://github.com/cristim/autospotting/issues/193

## Code contribution checklist

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [x] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
