### PR TITLE
Add a disallowed-instance-types option

### DIFF
--- a/autospotting.go
+++ b/autospotting.go
@@ -42,6 +42,7 @@ func run() {
 		"min_on_demand_number=%d "+
 		"min_on_demand_percentage=%.1f "+
 		"allowed_instance_types=%v "+
+		"disallowed_instance_types=%v "+
 		"on_demand_price_multiplier=%.2f"+
 		"spot_price_buffer_percentage=%.3f"+
 		"bidding_policy=%s",
@@ -49,6 +50,7 @@ func run() {
 		conf.MinOnDemandNumber,
 		conf.MinOnDemandPercentage,
 		conf.AllowedInstanceTypes,
+		conf.DisallowedInstanceTypes,
 		conf.OnDemandPriceMultiplier,
 		conf.SpotPriceBufferPercentage,
 		conf.BiddingPolicy)
@@ -122,6 +124,12 @@ func (c *cfgData) parseCommandLineFlags() {
 		"If specified, the spot instances will have a specific instance type:\n"+
 			"\tcurrent: the same as initial on-demand instances\n"+
 			"\t<instance-type>: the actual instance type to use")
+
+	flag.StringVar(&c.DisallowedInstanceTypes, "disallowed_instance_types", "",
+		"If specified, the spot instances will _never_ be of this type. "+
+			"This should be a list of instance types (comma or whitespace separated, "+
+			"also supports globs).\n\t"+
+			"Example: ./autospotting -disallowed_instance_types 't2.*,c4.xlarge'")
 
 	flag.Float64Var(&c.OnDemandPriceMultiplier, "on_demand_price_multiplier", 1.0,
 		"Multiplier for the on-demand price. This is useful for volume discounts or if you want to\n"+

--- a/cloudformation/stacks/AutoSpotting/template.json
+++ b/cloudformation/stacks/AutoSpotting/template.json
@@ -66,6 +66,11 @@
       "Default": "",
       "Description": "Comma separated list of allowed instance types for spot, in case you may want to limit it to a smaller set of instance types. If unset, instances will be chosen by autospotting's algorithm. Example: 'm4.xlarge,r4.xlarge'",
       "Type": "String"
+    },
+    "DisallowedInstanceTypes": {
+      "Default": "",
+      "Description": "Comma separated list of disallowed instance types for spot, in case you want to exclude specific types (also support globs). Example: 't2.*,m4.large'",
+      "Type": "String"
     }
   },
   "Resources": {
@@ -101,7 +106,8 @@
             "SPOT_PRICE_BUFFER_PERCENTAGE": { "Ref": "SpotPricePercentageBuffer"},
             "BIDDING_POLICY": { "Ref": "BiddingPolicy"},
             "REGIONS": { "Ref": "Regions" },
-            "ALLOWED_INSTANCE_TYPES": { "Ref": "AllowedInstanceTypes" }
+            "ALLOWED_INSTANCE_TYPES": { "Ref": "AllowedInstanceTypes" },
+            "DISALLOWED_INSTANCE_TYPES": { "Ref": "DisallowedInstanceTypes" }
           }
         },
         "Handler": { "Ref": "LambdaHandlerFunction" },

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -599,7 +599,6 @@ func (a *autoScalingGroup) havingReadyToAttachSpotInstance() (*string, bool) {
 }
 
 func (a *autoScalingGroup) getAllowedInstanceTypes(baseInstance *instance) []string {
-
 	var allowed, allowedInstanceTypesTag string
 
 	// Check option of allowed instance types
@@ -620,7 +619,26 @@ func (a *autoScalingGroup) getAllowedInstanceTypes(baseInstance *instance) []str
 		return []string{baseInstance.typeInfo.instanceType}
 	}
 	return strings.Split(allowed, ",")
+}
 
+func (a *autoScalingGroup) getDisallowedInstanceTypes(baseInstance *instance) []string {
+	var disallowed, disallowedInstanceTypesTag string
+
+	// Check option of allowed instance types
+	// If we have that option we don't need to calculate the compatible instance type.
+	if tagValue := a.getTagValue("disallowed-instance-types"); tagValue != nil {
+		disallowedInstanceTypesTag = strings.Replace(*tagValue, " ", ",", -1)
+	}
+	disallowedInstanceTypes := strings.Replace(a.region.conf.DisallowedInstanceTypes, " ", ",", -1)
+
+	// Command line config has a priority
+	if disallowedInstanceTypes != "" {
+		disallowed = disallowedInstanceTypes
+	} else {
+		disallowed = disallowedInstanceTypesTag
+	}
+
+	return strings.Split(disallowed, ",")
 }
 
 func (a *autoScalingGroup) getPricetoBid(
@@ -657,8 +675,9 @@ func (a *autoScalingGroup) launchCheapestSpotInstance(
 	logger.Println("Found on-demand instance", baseInstance.InstanceId)
 
 	allowedInstances := a.getAllowedInstanceTypes(baseInstance)
+	disallowedInstances := a.getDisallowedInstanceTypes(baseInstance)
 
-	newInstanceType, err := baseInstance.getCheapestCompatibleSpotInstanceType(allowedInstances)
+	newInstanceType, err := baseInstance.getCheapestCompatibleSpotInstanceType(allowedInstances, disallowedInstances)
 	if err != nil {
 		logger.Println("No cheaper compatible instance type was found, "+
 			"nothing to do here...", err)

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -3033,6 +3033,103 @@ func TestGetAllowedInstaceTypes(t *testing.T) {
 	}
 }
 
+func TestGetDisallowedInstaceTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		expected     []string
+		instanceInfo *instance
+		asg          *autoScalingGroup
+		asgtags      []*autoscaling.TagDescription
+	}{
+		{name: "Single Type Tag c2.xlarge",
+			expected: []string{"c2.xlarge"},
+			instanceInfo: &instance{
+				typeInfo: instanceTypeInformation{
+					instanceType: "typeX",
+				},
+				region: &region{},
+			},
+			asg: &autoScalingGroup{
+				name: "TestASG",
+				region: &region{
+					conf: &Config{
+						DisallowedInstanceTypes: "",
+					},
+				},
+				Group: &autoscaling.Group{
+					DesiredCapacity: aws.Int64(4),
+				},
+			},
+			asgtags: []*autoscaling.TagDescription{
+				{
+					Key:   aws.String("disallowed-instance-types"),
+					Value: aws.String("c2.xlarge"),
+				},
+			},
+		},
+		{name: "Single Type Cmd Line c2.xlarge",
+			expected: []string{"c2.xlarge"},
+			instanceInfo: &instance{
+				typeInfo: instanceTypeInformation{
+					instanceType: "typeX",
+				},
+				region: &region{},
+			},
+			asg: &autoScalingGroup{
+				name: "TestASG",
+				region: &region{
+					conf: &Config{
+						DisallowedInstanceTypes: "c2.xlarge",
+					},
+				},
+				Group: &autoscaling.Group{
+					DesiredCapacity: aws.Int64(4),
+				},
+			},
+			asgtags: []*autoscaling.TagDescription{},
+		},
+		{name: "Command line precedence on c2.xlarge",
+			expected: []string{"c2.xlarge"},
+			instanceInfo: &instance{
+				typeInfo: instanceTypeInformation{
+					instanceType: "typeX",
+				},
+				region: &region{},
+			},
+			asg: &autoScalingGroup{
+				name: "TestASG",
+				region: &region{
+					conf: &Config{
+						DisallowedInstanceTypes: "c2.xlarge",
+					},
+				},
+				Group: &autoscaling.Group{
+					DesiredCapacity: aws.Int64(4),
+				},
+			},
+			asgtags: []*autoscaling.TagDescription{
+				{
+					Key:   aws.String("disallowed-instance-types"),
+					Value: aws.String("c4.4xlarge"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := tt.asg
+			a.Tags = tt.asgtags
+			baseInstance := tt.instanceInfo
+			allowed := a.getDisallowedInstanceTypes(baseInstance)
+			if !reflect.DeepEqual(allowed, tt.expected) {
+				t.Errorf("Disallowed Instance Types does not match, received: %+v, expected: %+v",
+					allowed, tt.expected)
+			}
+		})
+	}
+}
+
 func TestGetPricetoBid(t *testing.T) {
 	tests := []struct {
 		spotPercentage       float64

--- a/core/config.go
+++ b/core/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	MinOnDemandPercentage     float64
 	Regions                   string
 	AllowedInstanceTypes      string
+	DisallowedInstanceTypes   string
 	OnDemandPriceMultiplier   float64
 	SpotPriceBufferPercentage float64
 	BiddingPolicy             string

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -748,6 +748,7 @@ func TestGetCheapestCompatibleSpotInstanceType(t *testing.T) {
 		expectedString string
 		expectedError  error
 		allowedList    []string
+		disallowedList []string
 	}{
 		{name: "better/cheaper spot instance found",
 			spotInfos: map[string]instanceTypeInformation{
@@ -834,6 +835,93 @@ func TestGetCheapestCompatibleSpotInstanceType(t *testing.T) {
 			},
 			expectedString: "type1",
 			expectedError:  nil,
+		},
+		{name: "better/cheaper spot instance found but marked as disallowed",
+			spotInfos: map[string]instanceTypeInformation{
+				"1": {
+					instanceType: "type1",
+					pricing: prices{
+						spot: map[string]float64{
+							"eu-central-1": 0.5,
+							"eu-west-1":    1.0,
+							"eu-west-2":    2.0,
+						},
+					},
+					vCPU:   10,
+					memory: 2.5,
+					instanceStoreDeviceCount: 1,
+					instanceStoreDeviceSize:  50.0,
+					instanceStoreIsSSD:       false,
+					virtualizationTypes:      []string{"PV", "else"},
+				},
+				"2": {
+					instanceType: "type2",
+					pricing: prices{
+						spot: map[string]float64{
+							"eu-central-1": 0.8,
+							"eu-west-1":    1.0,
+							"eu-west-2":    2.0,
+						},
+					},
+					vCPU:   10,
+					memory: 2.5,
+					instanceStoreDeviceCount: 1,
+					instanceStoreDeviceSize:  50.0,
+					instanceStoreIsSSD:       false,
+					virtualizationTypes:      []string{"PV", "else"},
+				},
+			},
+			instanceInfo: &instance{
+				Instance: &ec2.Instance{
+					VirtualizationType: aws.String("paravirtual"),
+					Placement: &ec2.Placement{
+						AvailabilityZone: aws.String("eu-central-1"),
+					},
+				},
+				typeInfo: instanceTypeInformation{
+					instanceType: "typeX",
+					vCPU:         10,
+					memory:       2.5,
+					instanceStoreDeviceCount: 1,
+					instanceStoreDeviceSize:  50.0,
+					instanceStoreIsSSD:       false,
+				},
+				price:  0.75,
+				region: &region{},
+			},
+			asg: &autoScalingGroup{
+				name: "test-asg",
+				instances: makeInstancesWithCatalog(
+					map[string]*instance{
+						"id-1": {
+							Instance: &ec2.Instance{
+								InstanceId:        aws.String("id-1"),
+								InstanceType:      aws.String("typeX"),
+								Placement:         &ec2.Placement{AvailabilityZone: aws.String("eu-west-1")},
+								InstanceLifecycle: aws.String("spot"),
+							},
+						},
+					},
+				),
+				Group: &autoscaling.Group{
+					DesiredCapacity: aws.Int64(4),
+				},
+			},
+			lc: &launchConfiguration{
+				LaunchConfiguration: &autoscaling.LaunchConfiguration{
+					BlockDeviceMappings: []*autoscaling.BlockDeviceMapping{
+						{
+							VirtualName: aws.String("vn1"),
+						},
+						{
+							VirtualName: aws.String("ephemeral"),
+						},
+					},
+				},
+			},
+			disallowedList: []string{"type*"},
+			expectedString: "",
+			expectedError:  errors.New("No cheaper spot instance types could be found"),
 		},
 		{name: "better/cheaper spot instance not found",
 			spotInfos: map[string]instanceTypeInformation{
@@ -930,7 +1018,8 @@ func TestGetCheapestCompatibleSpotInstanceType(t *testing.T) {
 			i.region.instanceTypeInformation = tt.spotInfos
 			i.asg = tt.asg
 			allowedList := tt.allowedList
-			retValue, err := i.getCheapestCompatibleSpotInstanceType(allowedList)
+			disallowedList := tt.disallowedList
+			retValue, err := i.getCheapestCompatibleSpotInstanceType(allowedList, disallowedList)
 			if err == nil && tt.expectedError != err {
 				t.Errorf("Error received: %v expected %v", err, tt.expectedError.Error())
 			} else if err != nil && tt.expectedError == nil {


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

This adds a new `disallowed-instance-types` option that can be set as a command line flag, environment variable, or ASG tag. It supports a comma separated list of instance types as well as globs. I needed this for https://github.com/cristim/autospotting/issues/190. While I don't think this closes that issue, it does offer a work around.

## Code contribution checklist

1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
