### PR TITLE
Allow larger number of autoscaling group names

### DIFF
--- a/core/region.go
+++ b/core/region.go
@@ -301,12 +301,9 @@ func (r *region) scanForEnabledAutoScalingGroups() {
 		return
 	}
 
-	svc := r.services.autoScaling
-
-	input := autoscaling.DescribeAutoScalingGroupsInput{}
 	pageNum := 0
-	err := svc.DescribeAutoScalingGroupsPages(
-		&input,
+	err := r.services.autoScaling.DescribeAutoScalingGroupsPages(
+		&autoscaling.DescribeAutoScalingGroupsInput{},
 		func(page *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
 			pageNum++
 			logger.Println("Processing page", pageNum, "of DescribeAutoScalingGroupsPages for", r.name)
@@ -316,7 +313,7 @@ func (r *region) scanForEnabledAutoScalingGroups() {
 					name:   *asg.AutoScalingGroupName,
 					region: r,
 				}
-				if containsString(group.name, asgNames) {
+				if containsString(asgNames, group.name) {
 					r.enabledASGs = append(r.enabledASGs, group)
 				}
 			}
@@ -332,7 +329,7 @@ func (r *region) scanForEnabledAutoScalingGroups() {
 	}
 }
 
-func containsString(a string, list []*string) bool {
+func containsString(list []*string, a string) bool {
 	for _, b := range list {
 		if *b == a {
 			return true

--- a/core/region.go
+++ b/core/region.go
@@ -330,6 +330,9 @@ func (r *region) scanForEnabledAutoScalingGroups() {
 }
 
 func containsString(list []*string, a string) bool {
+	if list == nil || len(list) == 0 {
+		return false
+	}
 	for _, b := range list {
 		if *b == a {
 			return true

--- a/core/region.go
+++ b/core/region.go
@@ -303,9 +303,7 @@ func (r *region) scanForEnabledAutoScalingGroups() {
 
 	svc := r.services.autoScaling
 
-	input := autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: asgNames,
-	}
+	input := autoscaling.DescribeAutoScalingGroupsInput{}
 	pageNum := 0
 	err := svc.DescribeAutoScalingGroupsPages(
 		&input,
@@ -318,7 +316,9 @@ func (r *region) scanForEnabledAutoScalingGroups() {
 					name:   *asg.AutoScalingGroupName,
 					region: r,
 				}
-				r.enabledASGs = append(r.enabledASGs, group)
+				if containsString(group.name, asgNames) {
+					r.enabledASGs = append(r.enabledASGs, group)
+				}
 			}
 			return true
 		},
@@ -330,6 +330,15 @@ func (r *region) scanForEnabledAutoScalingGroups() {
 			err.Error())
 		return
 	}
+}
+
+func containsString(a string, list []*string) bool {
+	for _, b := range list {
+		if *b == a {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *region) hasEnabledAutoScalingGroups() bool {

--- a/core/region_test.go
+++ b/core/region_test.go
@@ -249,3 +249,45 @@ func TestOnDemandPriceMultiplier(t *testing.T) {
 		}
 	}
 }
+
+func TestContainsString(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		list []*string
+		want bool
+	}{
+		{
+			name: "Test successful match",
+			key:  "test_key",
+			list: []*string{aws.String("test_key"), aws.String("test_key1")},
+			want: true,
+		},
+		{
+			name: "Test zero match",
+			key:  "not_found",
+			list: []*string{aws.String("test_key"), aws.String("test_key1")},
+			want: false,
+		},
+		{
+			name: "Test empty array",
+			key:  "not_found",
+			list: []*string{},
+			want: false,
+		},
+		{
+			name: "Test nil array",
+			key:  "not_found",
+			list: nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			received := containsString(tt.list, tt.key)
+			if tt.want != received {
+				t.Errorf("region.containsString() = %v, want %v", received, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request

## Summary

https://github.com/cristim/autospotting/issues/199

## Code contribution checklist

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
