### PR TITLE
disallowed-type: improve logic & add option in terraform/doc

### DIFF
--- a/START.md
+++ b/START.md
@@ -121,6 +121,7 @@ use the module directly:
 module "autospotting" {
   source = "github.com/cristim/autospotting/terraform/autospotting"
 
+  autospotting_disallowed_instance_types = "t2.*"
   autospotting_min_on_demand_number = "0"
   autospotting_min_on_demand_percentage = "50.0"
   autospotting_regions_enabled = "eu*,us*"

--- a/autospotting.go
+++ b/autospotting.go
@@ -117,7 +117,7 @@ func (c *cfgData) parseCommandLineFlags() {
 		"On-demand capacity (percentage of the total number of instances in the group) "+
 			"ensured to be running in each of your groups.\n\t"+
 			"Can be overridden on a per-group basis using the tag "+
-			autospotting.OnDemandPercentageLong+
+			autospotting.OnDemandPercentageTag+
 			"\n\tIt is ignored if min_on_demand_number is also set.")
 
 	flag.StringVar(&c.AllowedInstanceTypes, "allowed_instance_types", "",

--- a/cloudformation/stacks/AutoSpotting/parameters.yaml
+++ b/cloudformation/stacks/AutoSpotting/parameters.yaml
@@ -4,9 +4,9 @@
 
 # This file is handled automatically using the clouds-aws tool. It can be
 # installed using pip, or from https://github.com/elias5000/clouds-aws
-LambdaZipPath: nightly/lambda_build_458.zip
+LambdaZipPath: nightly/lambda_build_584.zip
 LambdaHandlerFunction: handler.Handle
 LambdaS3Bucket: cloudprowess
-LambdaMemorySize: '256'
+LambdaMemorySize: '1024'
 ExecutionFrequency: "rate(1 minute)"
 MinOnDemandNumber: '1'

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -95,7 +95,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("text"),
 				},
 			},
@@ -111,7 +111,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("142.2"),
 				},
 			},
@@ -127,7 +127,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("-22"),
 				},
 			},
@@ -143,7 +143,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("0"),
 				},
 			},
@@ -162,7 +162,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("33.0"),
 				},
 			},
@@ -184,7 +184,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("75.0"),
 				},
 			},
@@ -206,7 +206,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("100.0"),
 				},
 			},
@@ -320,7 +320,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("75"),
 				},
 				{
@@ -347,7 +347,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("75"),
 				},
 				{
@@ -374,7 +374,7 @@ func TestLoadConfOnDemand(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("-75"),
 				},
 				{
@@ -637,7 +637,7 @@ func TestLoadConfigFromTags(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("text"),
 				},
 				{
@@ -660,7 +660,7 @@ func TestLoadConfigFromTags(t *testing.T) {
 					Value: aws.String("asg-test"),
 				},
 				{
-					Key:   aws.String(OnDemandPercentageLong),
+					Key:   aws.String(OnDemandPercentageTag),
 					Value: aws.String("75"),
 				},
 				{
@@ -2945,7 +2945,7 @@ func TestGetAllowedInstaceTypes(t *testing.T) {
 			},
 			asgtags: []*autoscaling.TagDescription{
 				{
-					Key:   aws.String("allowed-instance-types"),
+					Key:   aws.String("autospotting_allowed_instance_types"),
 					Value: aws.String("c2.xlarge"),
 				},
 			},
@@ -3063,7 +3063,7 @@ func TestGetDisallowedInstanceTypes(t *testing.T) {
 			},
 			asgtags: []*autoscaling.TagDescription{
 				{
-					Key:   aws.String("disallowed-instance-types"),
+					Key:   aws.String("autospotting_disallowed_instance_types"),
 					Value: aws.String("c2.xlarge"),
 				},
 			},
@@ -3110,7 +3110,7 @@ func TestGetDisallowedInstanceTypes(t *testing.T) {
 			},
 			asgtags: []*autoscaling.TagDescription{
 				{
-					Key:   aws.String("disallowed-instance-types"),
+					Key:   aws.String("autospotting_disallowed_instance_types"),
 					Value: aws.String("c4.4xlarge"),
 				},
 			},

--- a/core/instance.go
+++ b/core/instance.go
@@ -238,7 +238,7 @@ func (i *instance) isAllowed(instanceType string, allowedList []string, disallow
 		}
 		debug.Println("Instance has been excluded since it was not in the allowed instance types list")
 		return false
-	} else if disallowedList != nil && disallowedList[0] != "" {
+	} else if len(disallowedList) > 0 {
 		for _, a := range disallowedList {
 			// glob matching
 			if match, _ := filepath.Match(a, instanceType); match {

--- a/terraform/autospotting.tf
+++ b/terraform/autospotting.tf
@@ -1,6 +1,7 @@
 module "autospotting" {
   source = "./autospotting"
 
+  autospotting_disallowed_instance_types    = "${var.asg_disallowed_instance_types}"
   autospotting_min_on_demand_number         = "${var.asg_min_on_demand_number}"
   autospotting_min_on_demand_percentage     = "${var.asg_min_on_demand_percentage}"
   autospotting_on_demand_price_multiplier   = "${var.asg_on_demand_price_multiplier}"

--- a/terraform/autospotting/lambda.tf
+++ b/terraform/autospotting/lambda.tf
@@ -10,6 +10,7 @@ resource "aws_lambda_function" "autospotting" {
 
   environment {
     variables = {
+      DISALLOWED_INSTANCE_TYPES    = "${var.autospotting_disallowed_instance_types}"
       MIN_ON_DEMAND_NUMBER         = "${var.autospotting_min_on_demand_number}"
       MIN_ON_DEMAND_PERCENTAGE     = "${var.autospotting_min_on_demand_percentage}"
       ON_DEMAND_PRICE_MULTIPLIER   = "${var.autospotting_on_demand_price_multiplier}"

--- a/terraform/autospotting/variables.tf
+++ b/terraform/autospotting/variables.tf
@@ -1,4 +1,14 @@
 # Autospotting configuration
+variable "autospotting_disallowed_instance_types" {
+  description = <<EOF
+Comma separated list of disallowed instance types for spot requests,
+in case you want to exclude specific types (also support globs).
+
+Example: 't2.*,m4.large'
+EOF
+  default = ""
+}
+
 variable "autospotting_min_on_demand_number" {
   description = "Minimum on-demand instances to keep in absolute value"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,14 @@
 # Autospotting configuration
+variable "asg_disallowed_instance_types" {
+  description = <<EOF
+Comma separated list of disallowed instance types for spot requests,
+in case you want to exclude specific types (also support globs).
+
+Example: 't2.*,m4.large'
+EOF
+  default = ""
+}
+
 variable "asg_min_on_demand_number" {
   description = "Minimum on demand number for all ASG enabled"
   default     = "0"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,7 +52,7 @@ variable "lambda_runtime" {
 
 variable "lambda_memory_size" {
   description = "Memory size allocated to the lambda run"
-  default     = 256
+  default     = 1024
 }
 
 variable "lambda_timeout" {


### PR DESCRIPTION
# Issue Type

- Feature Pull Request
- Bugfix Pull Request
- Documentation Pull Request

(All of the above)

## Summary

As reported [here](https://github.com/cristim/autospotting/issues/198) and [there](https://github.com/cristim/autospotting/pull/196#pullrequestreview-87979399). There were couple elements that could have been improved with the option.

This PR add/fixes:
* add terraform option & doc
* ensure no empty elements are within the list
* review logic, to give priority to ASG tags rather than global configuration

Closes: https://github.com/cristim/autospotting/issues/198

## Code contribution checklist

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [x] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
