### PR TITLE
autoscaling: add LC Name tag by default

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -385,6 +385,10 @@ func (a *autoScalingGroup) scanInstances() instances {
 func (a *autoScalingGroup) propagatedInstanceTags() []*ec2.Tag {
 	var tags []*ec2.Tag
 
+	tags = append(tags, &ec2.Tag{
+		Key:   aws.String("LaunchConfigurationName"),
+		Value: a.LaunchConfigurationName,
+	})
 	for _, asgTag := range a.Tags {
 		if *asgTag.PropagateAtLaunch && !strings.HasPrefix(*asgTag.Key, "aws:") {
 			tags = append(tags, &ec2.Tag{

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -2074,13 +2074,22 @@ func TestScanInstances(t *testing.T) {
 func TestPropagatedInstance(t *testing.T) {
 	tests := []struct {
 		name         string
+		ASGLCName    string
 		tagsASG      []*autoscaling.TagDescription
 		expectedTags []*ec2.Tag
 	}{
 		{name: "no tags on asg",
-			tagsASG: []*autoscaling.TagDescription{},
+			ASGLCName: "testLC0",
+			tagsASG:   []*autoscaling.TagDescription{},
+			expectedTags: []*ec2.Tag{
+				{
+					Key:   aws.String("LaunchConfigurationName"),
+					Value: aws.String("testLC0"),
+				},
+			},
 		},
 		{name: "multiple tags but none to propagate",
+			ASGLCName: "testLC1",
 			tagsASG: []*autoscaling.TagDescription{
 				{
 					Key:               aws.String("k1"),
@@ -2098,8 +2107,15 @@ func TestPropagatedInstance(t *testing.T) {
 					PropagateAtLaunch: aws.Bool(false),
 				},
 			},
+			expectedTags: []*ec2.Tag{
+				{
+					Key:   aws.String("LaunchConfigurationName"),
+					Value: aws.String("testLC1"),
+				},
+			},
 		},
 		{name: "multiple tags but none to propagate",
+			ASGLCName: "testLC2",
 			tagsASG: []*autoscaling.TagDescription{
 				{
 					Key:               aws.String("aws:k1"),
@@ -2117,8 +2133,15 @@ func TestPropagatedInstance(t *testing.T) {
 					PropagateAtLaunch: aws.Bool(false),
 				},
 			},
+			expectedTags: []*ec2.Tag{
+				{
+					Key:   aws.String("LaunchConfigurationName"),
+					Value: aws.String("testLC2"),
+				},
+			},
 		},
 		{name: "multiple tags on asg - only one to propagate",
+			ASGLCName: "testLC3",
 			tagsASG: []*autoscaling.TagDescription{
 				{
 					Key:               aws.String("k1"),
@@ -2138,6 +2161,10 @@ func TestPropagatedInstance(t *testing.T) {
 			},
 			expectedTags: []*ec2.Tag{
 				{
+					Key:   aws.String("LaunchConfigurationName"),
+					Value: aws.String("testLC3"),
+				},
+				{
 					Key:   aws.String("k2"),
 					Value: aws.String("v2"),
 				},
@@ -2149,6 +2176,7 @@ func TestPropagatedInstance(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &autoScalingGroup{
 				Group: &autoscaling.Group{
+					LaunchConfigurationName: aws.String(tt.ASGLCName),
 					Tags: tt.tagsASG,
 				},
 			}


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

To know from which LaunchConfiguration the spot instances were started
with, it seemed interesting to add such tag as default.

Closes: https://github.com/cristim/autospotting/issues/165

## Code contribution checklist

1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
