### PR TITLE
Use Security Group IDs in all cases

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -734,7 +734,7 @@ func (a *autoScalingGroup) getBaseAndNewInstanceTypeToStart(azToLaunchIn *string
 		logger.Println("Found no on-demand instances, nothing to do here...")
 		return nil, nil, errors.New("no on-demand instances found")
 	}
-	logger.Println("Found on-demand instance", baseInstance.InstanceId)
+	logger.Println("Found on-demand instance", *baseInstance.InstanceId)
 
 	allowedInstances := a.getAllowedInstanceTypes(baseInstance)
 	disallowedInstances := a.getDisallowedInstanceTypes(baseInstance)

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -857,7 +856,6 @@ func (a *autoScalingGroup) getLaunchConfiguration() *launchConfiguration {
 
 	a.launchConfiguration = &launchConfiguration{
 		LaunchConfiguration: resp.LaunchConfigurations[0],
-		secGroupRegex:       regexp.MustCompile(`^sg-[a-f0-9]{8,17}$`),
 	}
 	return a.launchConfiguration
 }

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -881,26 +881,6 @@ func (a *autoScalingGroup) detachAndTerminateOnDemandInstance(
 	return a.instances.get(*instanceID).terminate()
 }
 
-// Counts the number of already running spot instances.
-func (a *autoScalingGroup) alreadyRunningSpotInstanceTypeCount(
-	instanceType, availabilityZone string) int64 {
-
-	var count int64
-	logger.Println(a.name, "Counting already running spot instances of type ",
-		instanceType, " in AZ ", availabilityZone)
-	for inst := range a.instances.instances() {
-		if *inst.InstanceType == instanceType &&
-			*inst.Placement.AvailabilityZone == availabilityZone &&
-			inst.isSpot() {
-			logger.Println(a.name, "Found running spot instance ",
-				*inst.InstanceId, "of the same type:", instanceType)
-			count++
-		}
-	}
-	logger.Println(a.name, "Found", count, instanceType, "instances")
-	return count
-}
-
 // Counts the number of already running instances on-demand or spot, in any or a specific AZ.
 func (a *autoScalingGroup) alreadyRunningInstanceCount(
 	spot bool, availabilityZone string) (int64, int64) {

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -847,7 +847,7 @@ func (a *autoScalingGroup) getLaunchConfiguration() *launchConfiguration {
 
 	a.launchConfiguration = &launchConfiguration{
 		LaunchConfiguration: resp.LaunchConfigurations[0],
-		secGroupRegex:       regexp.MustCompile(`^sg-[a-f0-9]{8}$`),
+		secGroupRegex:       regexp.MustCompile(`^sg-[a-f0-9]{8,17}$`),
 	}
 	return a.launchConfiguration
 }

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -1586,7 +1586,6 @@ func TestGetLaunchConfiguration(t *testing.T) {
 				LaunchConfiguration: &autoscaling.LaunchConfiguration{
 					LaunchConfigurationName: aws.String("testLC"),
 				},
-				secGroupRegex: testSecGroupRegex,
 			},
 		},
 		{name: "err during get launch configuration",

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -1586,6 +1586,7 @@ func TestGetLaunchConfiguration(t *testing.T) {
 				LaunchConfiguration: &autoscaling.LaunchConfiguration{
 					LaunchConfigurationName: aws.String("testLC"),
 				},
+				secGroupRegex: testSecGroupRegex,
 			},
 		},
 		{name: "err during get launch configuration",

--- a/core/launch_configuration.go
+++ b/core/launch_configuration.go
@@ -12,9 +12,9 @@ import (
 
 type launchConfiguration struct {
 	*autoscaling.LaunchConfiguration
-
-	secGroupRegex *regexp.Regexp
 }
+
+var secGroupRegex = regexp.MustCompile(`^sg-[a-f0-9]{8,17}$`)
 
 func (lc *launchConfiguration) countLaunchConfigEphemeralVolumes() int {
 	count := 0
@@ -163,7 +163,7 @@ func (lc *launchConfiguration) getSecurityGroupIDs(conn *connections, secGroups 
 
 	for _, secGroupStr := range secGroups {
 		// we assume strings that match are IDs already
-		if lc.secGroupRegex.MatchString(*secGroupStr) {
+		if secGroupRegex.MatchString(*secGroupStr) {
 			ids = append(ids, aws.String(*secGroupStr))
 		} else {
 			names = append(names, aws.String(*secGroupStr))

--- a/core/launch_configuration.go
+++ b/core/launch_configuration.go
@@ -158,12 +158,8 @@ func copyBlockDeviceMappings(
 // that the ones starting with "sg-" are ids and then search for the IDs
 // of the other ones.
 func (lc *launchConfiguration) getSecurityGroupIDs(conn *connections, secGroups []*string) ([]*string, error) {
-	var (
-		names    []*string
-		ids      []*string
-		outNames *ec2.DescribeSecurityGroupsOutput
-		err      error
-	)
+	var names []*string
+	var ids []*string
 
 	for _, secGroupStr := range secGroups {
 		// we assume strings that match are IDs already
@@ -174,21 +170,21 @@ func (lc *launchConfiguration) getSecurityGroupIDs(conn *connections, secGroups 
 		}
 	}
 
-	if len(names) > 0 {
-		inputNames := &ec2.DescribeSecurityGroupsInput{
-			GroupNames: names,
-		}
-
-		outNames, err = conn.ec2.DescribeSecurityGroups(inputNames)
-		if err != nil {
-			return nil, err
-		}
+	if len(names) == 0 {
+		return ids, nil
 	}
 
-	if outNames != nil {
-		for _, group := range outNames.SecurityGroups {
-			ids = append(ids, aws.String(*group.GroupId))
-		}
+	inputNames := &ec2.DescribeSecurityGroupsInput{
+		GroupNames: names,
+	}
+
+	outNames, err := conn.ec2.DescribeSecurityGroups(inputNames)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, group := range outNames.SecurityGroups {
+		ids = append(ids, aws.String(*group.GroupId))
 	}
 
 	return ids, nil

--- a/core/launch_configuration_test.go
+++ b/core/launch_configuration_test.go
@@ -2,7 +2,6 @@ package autospotting
 
 import (
 	"reflect"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -106,8 +105,6 @@ func Test_copyBlockDeviceMappings(t *testing.T) {
 	}
 }
 
-var testSecGroupRegex = regexp.MustCompile(`^sg-[a-f0-9]{8,17}$`)
-
 func Test_countLaunchConfigEphemeralVolumes(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -183,7 +180,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 			name: "empty everything",
 			lc: &launchConfiguration{
 				&autoscaling.LaunchConfiguration{},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -200,7 +196,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 			name: "empty structs, but with az and instanceType",
 			lc: &launchConfiguration{
 				&autoscaling.LaunchConfiguration{},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -222,7 +217,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					EbsOptimized: aws.Bool(true),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -253,7 +247,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					EbsOptimized: aws.Bool(false),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -284,7 +277,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					IamInstanceProfile: aws.String("arn:aws:something"),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -305,7 +297,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					IamInstanceProfile: aws.String("bla bla bla something"),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -326,7 +317,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					KeyName: aws.String("key xyz"),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -347,7 +337,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 						Enabled: aws.Bool(false),
 					},
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -368,7 +357,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					UserData: aws.String("user data"),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -387,7 +375,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					AssociatePublicIpAddress: aws.Bool(true),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -411,7 +398,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					SecurityGroups: aws.StringSlice([]string{"non-sgstart", "non-sg"}),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -430,7 +416,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					SecurityGroups: aws.StringSlice([]string{"sg-12345fdd", "sg-4567fed0"}),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -452,7 +437,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					SecurityGroups: aws.StringSlice([]string{"sg-12345", "sg-4567"}),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -472,7 +456,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					SecurityGroups: aws.StringSlice([]string{"sg-123456aedf6aedf78", "sg-2671decc18123770b"}),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -492,7 +475,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				&autoscaling.LaunchConfiguration{
 					SecurityGroups: aws.StringSlice([]string{"sg-12345678", "non-sg"}),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},
@@ -517,7 +499,6 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 					KeyName:      aws.String("key xyz"),
 					EbsOptimized: aws.Bool(true),
 				},
-				testSecGroupRegex,
 			},
 			instance: &instance{
 				Instance: &ec2.Instance{},

--- a/core/launch_configuration_test.go
+++ b/core/launch_configuration_test.go
@@ -106,7 +106,7 @@ func Test_copyBlockDeviceMappings(t *testing.T) {
 	}
 }
 
-var testSecGroupRegex = regexp.MustCompile(`^sg-[a-f0-9]{8}$`)
+var testSecGroupRegex = regexp.MustCompile(`^sg-[a-f0-9]{8,17}$`)
 
 func Test_countLaunchConfigEphemeralVolumes(t *testing.T) {
 	tests := []struct {
@@ -428,6 +428,28 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 			name: "classic-id-networking",
 			lc: &launchConfiguration{
 				&autoscaling.LaunchConfiguration{
+					SecurityGroups: aws.StringSlice([]string{"sg-12345fdd", "sg-4567fed0"}),
+				},
+				testSecGroupRegex,
+			},
+			instance: &instance{
+				Instance: &ec2.Instance{},
+			},
+			spotRequest: &ec2.RequestSpotLaunchSpecification{
+				InstanceType:   aws.String(""),
+				SecurityGroups: nil,
+				Placement: &ec2.SpotPlacement{
+					AvailabilityZone: aws.String(""),
+				},
+				SecurityGroupIds: aws.StringSlice([]string{"sg-12345fdd", "sg-4567fed0"}),
+			},
+		},
+		{
+			// these look like real ids but they are not and will be treated as
+			// names
+			name: "classic-fake-id-networking",
+			lc: &launchConfiguration{
+				&autoscaling.LaunchConfiguration{
 					SecurityGroups: aws.StringSlice([]string{"sg-12345", "sg-4567"}),
 				},
 				testSecGroupRegex,
@@ -442,6 +464,26 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 					AvailabilityZone: aws.String(""),
 				},
 				SecurityGroupIds: aws.StringSlice([]string{"sg-12345", "sg-4567"}),
+			},
+		},
+		{
+			name: "classic-long-id-networking",
+			lc: &launchConfiguration{
+				&autoscaling.LaunchConfiguration{
+					SecurityGroups: aws.StringSlice([]string{"sg-123456aedf6aedf78", "sg-2671decc18123770b"}),
+				},
+				testSecGroupRegex,
+			},
+			instance: &instance{
+				Instance: &ec2.Instance{},
+			},
+			spotRequest: &ec2.RequestSpotLaunchSpecification{
+				InstanceType:   aws.String(""),
+				SecurityGroups: nil,
+				Placement: &ec2.SpotPlacement{
+					AvailabilityZone: aws.String(""),
+				},
+				SecurityGroupIds: aws.StringSlice([]string{"sg-123456aedf6aedf78", "sg-2671decc18123770b"}),
 			},
 		},
 		{

--- a/core/launch_configuration_test.go
+++ b/core/launch_configuration_test.go
@@ -421,7 +421,7 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				Placement: &ec2.SpotPlacement{
 					AvailabilityZone: aws.String(""),
 				},
-				SecurityGroupIds: aws.StringSlice([]string{"sg-non-sgstart", "sg-non-sg"}),
+				SecurityGroupIds: aws.StringSlice([]string{"sg-non-sgstart", "sg-non-sgde"}),
 			},
 		},
 		{
@@ -463,7 +463,7 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				Placement: &ec2.SpotPlacement{
 					AvailabilityZone: aws.String(""),
 				},
-				SecurityGroupIds: aws.StringSlice([]string{"sg-12345", "sg-4567"}),
+				SecurityGroupIds: aws.StringSlice([]string{"sg-12345dea", "sg-4567dead"}),
 			},
 		},
 		{
@@ -490,7 +490,7 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 			name: "classic-mixed-networking",
 			lc: &launchConfiguration{
 				&autoscaling.LaunchConfiguration{
-					SecurityGroups: aws.StringSlice([]string{"sg-12345", "non-sg"}),
+					SecurityGroups: aws.StringSlice([]string{"sg-12345678", "non-sg"}),
 				},
 				testSecGroupRegex,
 			},
@@ -502,7 +502,7 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				Placement: &ec2.SpotPlacement{
 					AvailabilityZone: aws.String(""),
 				},
-				SecurityGroupIds: aws.StringSlice([]string{"sg-12345", "sg-non-sg"}),
+				SecurityGroupIds: aws.StringSlice([]string{"sg-12345678", "sg-non-sgde"}),
 			},
 		},
 		{

--- a/core/launch_configuration_test.go
+++ b/core/launch_configuration_test.go
@@ -407,7 +407,7 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				Placement: &ec2.SpotPlacement{
 					AvailabilityZone: aws.String(""),
 				},
-				SecurityGroups: aws.StringSlice([]string{"non-sgstart", "non-sg"}),
+				SecurityGroupIds: aws.StringSlice([]string{"sg-non-sgstart", "sg-non-sg"}),
 			},
 		},
 		{
@@ -440,12 +440,11 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 				Instance: &ec2.Instance{},
 			},
 			spotRequest: &ec2.RequestSpotLaunchSpecification{
-				InstanceType:   aws.String(""),
-				SecurityGroups: aws.StringSlice([]string{"sg-12345", "non-sg"}),
+				InstanceType: aws.String(""),
 				Placement: &ec2.SpotPlacement{
 					AvailabilityZone: aws.String(""),
 				},
-				SecurityGroupIds: nil,
+				SecurityGroupIds: aws.StringSlice([]string{"sg-12345", "sg-non-sg"}),
 			},
 		},
 		{
@@ -487,7 +486,10 @@ func Test_convertLaunchConfigurationToSpotSpecification(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			spot := tc.lc.convertLaunchConfigurationToSpotSpecification(tc.instance, tc.instanceType, tc.az)
+			spot, err := tc.lc.convertLaunchConfigurationToSpotSpecification(tc.instance, tc.instanceType, &connections{ec2: &mockEC2{}}, tc.az)
+			if err != nil {
+				t.Errorf("expected no error but got %s", err)
+			}
 			if !reflect.DeepEqual(spot, tc.spotRequest) {
 				t.Errorf("expected: %+v\nactual: %+v", tc.spotRequest, spot)
 			}

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -100,15 +100,33 @@ func (m mockEC2) DescribeRegions(*ec2.DescribeRegionsInput) (*ec2.DescribeRegion
 }
 
 // For testing we "convert" the SecurityGroupIDs/SecurityGroupNames by
-// prefixing the original name/id with "sg-" if not present already.
+// prefixing the original name/id with "sg-" if not present already. We
+// also fill up the rest of the string to the length of a typical ID with
+// characters taken from the string "deadbeef"
 func (m mockEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
 	var groups []*ec2.SecurityGroup
+
+	// we use this string to fill the length of an SecurityGroup name to an
+	// ID if the name is too short to be a correct ID
+	const testFillStringID = "deadbeef"
+
+	// "sg-" + 8 hex characters
+	const testLengthIDString = 11
 
 	for _, groupName := range input.GroupNames {
 		newgroup := *groupName
 
 		if !strings.HasPrefix(*groupName, "sg-") {
 			newgroup = "sg-" + *groupName
+		}
+
+		// a SecurityGroupID is supposed to have a length of 11
+		// characters. We fill up the missing characters to indicate that this is
+		// now an ID and that it was treated as a name before
+		lenng := len(newgroup)
+		if lenng < testLengthIDString {
+			needed := testLengthIDString - lenng
+			newgroup = newgroup + testFillStringID[:needed]
 		}
 
 		groups = append(groups, &ec2.SecurityGroup{GroupId: &newgroup})

--- a/terraform/autospotting/autospotting-policy.json
+++ b/terraform/autospotting/autospotting-policy.json
@@ -15,6 +15,7 @@
         "ec2:DescribeSpotInstanceRequests",
         "ec2:DescribeSpotPriceHistory",
         "ec2:RequestSpotInstances",
+        "ec2:DescribeSecurityGroups",
         "ec2:TerminateInstances",
         "iam:PassRole",
         "iam:CreateServiceLinkedRole",


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request for https://github.com/cristim/autospotting/issues/48.


## Summary

This PR is one way to fix https://github.com/cristim/autospotting/issues/48.  (The first commit is just an unrelated cleanup commit however.)

We want to attach the correct SecurityGroups to newly created spot instances. For that we just reuse the SecurityGroup attached to the instances in the auto scaling group but it turns out that those Security Groups can either be mentioned by name (in the classic EC2 or the DefaultVPC case) or by id (in the Lunix/UNIX (VPC) case).

In order to make the handling of these different cases easier we try to use IDs in all cases. If a SecurityGroup string starts with "sg-" we assume it's an idea already and use it as is. Otherwise we search for the string as a group name using the AWS EC2 API and use its ID.

I think this should also cover the case where the security groups of the instance are mentioned in a mixed way, containing both names and IDs (as long as the names don't start with "sg-").

In our environment I can only test the DefaultVPC case so we have to make sure that this approach still works for all of the other cases.