### PR TITLE
Add a sleep to let detachment initialize properly before terminating

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -917,6 +917,9 @@ func (a *autoScalingGroup) detachAndTerminateOnDemandInstance(
 		return err
 	}
 
+	// Wait till detachment is complete before terminate instance
+	time.Sleep(20 * time.Second)
+
 	return a.instances.get(*instanceID).terminate()
 }
 

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -918,7 +918,7 @@ func (a *autoScalingGroup) detachAndTerminateOnDemandInstance(
 	}
 
 	// Wait till detachment initialize is complete before terminate instance
-    time.Sleep(20 * time.Second * s.region.conf.SleepMultiplier)
+    time.Sleep(20 * time.Second * a.region.conf.SleepMultiplier)
 
 	return a.instances.get(*instanceID).terminate()
 }

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -917,7 +917,7 @@ func (a *autoScalingGroup) detachAndTerminateOnDemandInstance(
 		return err
 	}
 
-	// Wait till detachment is complete before terminate instance
+	// Wait till detachment initialize is complete before terminate instance
 	time.Sleep(20 * time.Second)
 
 	return a.instances.get(*instanceID).terminate()

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -918,7 +918,7 @@ func (a *autoScalingGroup) detachAndTerminateOnDemandInstance(
 	}
 
 	// Wait till detachment initialize is complete before terminate instance
-    time.Sleep(20 * time.Second * a.region.conf.SleepMultiplier)
+	time.Sleep(20 * time.Second * a.region.conf.SleepMultiplier)
 
 	return a.instances.get(*instanceID).terminate()
 }

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -918,7 +918,7 @@ func (a *autoScalingGroup) detachAndTerminateOnDemandInstance(
 	}
 
 	// Wait till detachment initialize is complete before terminate instance
-	time.Sleep(20 * time.Second)
+    time.Sleep(20 * time.Second * s.region.conf.SleepMultiplier)
 
 	return a.instances.get(*instanceID).terminate()
 }

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -1419,6 +1419,7 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 				services: connections{
 					autoScaling: mockASG{dierr: nil},
 				},
+				conf: &Config{},
 			},
 			instanceID: aws.String("1"),
 			expected:   nil,
@@ -1443,6 +1444,7 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 				services: connections{
 					autoScaling: mockASG{dierr: errors.New("detach")},
 				},
+				conf: &Config{},
 			},
 			instanceID: aws.String("1"),
 			expected:   errors.New("detach"),
@@ -1467,6 +1469,7 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 				services: connections{
 					autoScaling: mockASG{dierr: nil},
 				},
+				conf: &Config{},
 			},
 			instanceID: aws.String("1"),
 			expected:   errors.New("terminate"),
@@ -1491,6 +1494,7 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 				services: connections{
 					autoScaling: mockASG{dierr: errors.New("detach")},
 				},
+				conf: &Config{},
 			},
 			instanceID: aws.String("1"),
 			expected:   errors.New("detach"),
@@ -2705,6 +2709,7 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 				),
 				region: &region{
 					name: "test-region",
+					conf: &Config{},
 					services: connections{
 						autoScaling: &mockASG{
 							uasgo:   nil,
@@ -2804,6 +2809,7 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 				),
 				region: &region{
 					name: "test-region",
+					conf: &Config{},
 					services: connections{
 						autoScaling: &mockASG{
 							uasgo:   nil,
@@ -2851,6 +2857,7 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 				},
 				region: &region{
 					name: "test-region",
+					conf: &Config{},
 					services: connections{
 						autoScaling: &mockASG{
 							uasgo:   nil,
@@ -2903,6 +2910,7 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 				instances: makeInstances(),
 				region: &region{
 					name: "test-region",
+					conf: &Config{},
 					services: connections{
 						autoScaling: &mockASG{
 							uasgo:   nil,


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request


## Summary

When detaching an instance from a Autoscaling Group autospotting just starts the detach and then immediately terminate the instance, this will make some requests during this time fail:
To reproduce: create an ALB, put 2 instances with a simple webserver for example  [http-echo](https://github.com/hashicorp/http-echo) and launch 2 new instances, result will be some missing requests when autospotting swap the on-demand instance to  spot-instances

```

Sun Apr 8 14:12:23 CEST 2018 version4: ip-10-0-62-37
Sun Apr 8 14:12:23 CEST 2018<html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
</body>
</html>
Sun Apr 8 14:12:23 CEST 2018<html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
</body>
</html>
Sun Apr 8 14:12:23 CEST 2018 version4: ip-10-0-62-37

```
It probably would be better to evaluate the detachment process in some way, but as a quick fix this should be sufficient. I don't know what you prefer?

