### PR TITLE
Add support for opt-out mode

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -154,8 +154,13 @@ If you find AutoSpotting useful please consider giving a recurring tip on
 
 The entire configuration is based on tags applied on your AutoScaling groups.
 
-It will only take action against groups that have the "spot-enabled" tag set to
-"true", regardless in which region they are.
+By default it runs in `opt-in` mode, so it will only take action against groups
+that have the `spot-enabled` tag set to `true`, across all the enabled regions.
+
+When the stack is installed in `opt-out` mode, it will run against all groups
+except for those tagged with the `spot-enabled` tag set to `false`.
+
+Note: the key and value of the `spot-enabled` tag is configurable in both modes.
 
 ## What if I have groups in multiple AWS regions?
 
@@ -606,6 +611,9 @@ is by configuring autospotting to use 100% on-demand capacity.
 Fine-grained control on a per group level can be achieved by removing or setting
 the `spot-enabled` tag to any other value. AutoSpotting only touches groups
 where this tag is set to `true`.
+
+Note: this is the default tag configuration, but it is configurable so you may
+be using different values.
 
 ## Shall I contribute to Autospotting code?
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Just like in the above animation, it's as easy as launching a CloudFormation (or
 stack and setting the (configurable) `spot-enabled` tag on the AutoScaling
 groups where you want it enabled to `true`.
 
+The stack can also be configured in an `opt-out` filtering mode, in which it
+runs against all groups except for those tagged with the (configurable)
+`spot-enabled` tag set to `false`, which can be useful for large scale rollouts.
+
 All the required infrastructure and configuration will be created automatically,
 so you can get started as fast as possible.
 

--- a/START.md
+++ b/START.md
@@ -134,23 +134,28 @@ use the module directly:
 module "autospotting" {
   source = "github.com/cristim/autospotting//terraform/autospotting"
 
-  autospotting_disallowed_instance_types = "t2.*"
-  autospotting_min_on_demand_number = "0"
-  autospotting_min_on_demand_percentage = "50.0"
-  autospotting_regions_enabled = "eu*,us*"
-  autospotting_tag_filters = "spot-enabled=true,environment=dev,team=interactive"
-  autospotting_on_demand_price_multiplier = "1.0"
-  autospotting_spot_price_buffer_percentage = "10.0"
-  autospotting_bidding_policy = "normal"
-  autospotting_spot_product_description = "Linux/UNIX (Amazon VPC)"
 
-  lambda_zipname = "./lambda.zip"
-  lambda_runtime = "go1.x"
-  lambda_memory_size = "256"
-  lambda_timeout = "300"
+  autospotting_disallowed_instance_types    = "t2.*"
+  autospotting_min_on_demand_number         = "0"
+  autospotting_min_on_demand_percentage     = "50.0"
+  autospotting_regions_enabled              = "eu*,us*"
+  autospotting_tag_filters                  = "spot-enabled=true,environment=dev,team=interactive"
+  autospotting_on_demand_price_multiplier   = "1.0"
+  autospotting_spot_price_buffer_percentage = "10.0"
+  autospotting_bidding_policy               = "normal"
+  autospotting_tag_filtering_mode           = "opt-in"
+  autospotting_spot_product_description     = "Linux/UNIX (Amazon VPC)"
+
+  lambda_zipname       = "./lambda.zip"
+  lambda_runtime       = "go1.x"
+  lambda_memory_size   = "256"
+  lambda_timeout       = "300"
   lambda_run_frequency = "rate(5 minutes)"
 }
 ```
+
+Note: this snippet may be outdated, please see the Terraform module for the
+current module parameters.
 
 #### Install module from S3 ####
 
@@ -169,9 +174,9 @@ module "autospotting" {
 
 ### For an AutoScaling group ###
 
-Since AutoSpotting uses an opt-in model, no resources will be changed in your
-AWS account if you just launch the stack. You will need to explicitly enable it
-for each AutoScaling group where you want it to be used.
+Since AutoSpotting by default uses an opt-in model, no resources will be changed
+in your AWS account if you just launch the stack. You will need to explicitly
+enable it for each AutoScaling group where you want it to be used.
 
 Enabling it for an AutoScaling group is a matter of setting a tag on the group:
 
@@ -216,6 +221,15 @@ One good way to automate is using CloudFormation, using this example snippet:
   }
 }
 ```
+
+**Note:** The `spot-enabled=true` tag for `opt-in` is configurable. See the
+stack parameters for the way to override it.
+
+**Note:** AutoSpotting now also supports an `opt-out` mode, in which it will
+take over all your groups except of those tagged with the configured tag. The
+default (but also configurable) `opt-out` tag is `spot-enabled=false`. This may
+be risky, please handle with care.
+
 
 ### For Elastic Beanstalk ###
 

--- a/TECHNICAL_DETAILS.md
+++ b/TECHNICAL_DETAILS.md
@@ -15,7 +15,8 @@
 | Can restrict to the same instance type only | :white_check_mark: | :white_check_mark: |
 | Can restrict to only certain instance types | :white_check_mark: | :white_check_mark: |
 | Blacklisting of certain instance types | :white_check_mark: | :white_check_mark: |
-| Filter on multiple & custom group tags | :white_check_mark:  (default: spot-enabled=true)  | :heavy_minus_sign: |
+| Filter on multiple & custom group tags | :white_check_mark:  (default: `spot-enabled=true`)  | :heavy_minus_sign: |
+| Configurable filtering modes(`opt-in` and `opt-out`) | :white_check_mark:  (default: `opt-in`)| :heavy_minus_sign: |
 | Set a desired spot product name | :white_check_mark: | :x: :wrench: - install multiple stacks, each with its own spot product|
 
 For the options not directly linked to any specific part of the doc, please

--- a/autospotting.go
+++ b/autospotting.go
@@ -44,6 +44,7 @@ func run() {
 		"spot_price_buffer_percentage=%.3f "+
 		"bidding_policy=%s "+
 		"tag_filters=%s "+
+		"tag_filter_mode=%s "+
 		"spot_product_description=%v",
 		conf.Regions,
 		conf.MinOnDemandNumber,
@@ -54,6 +55,7 @@ func run() {
 		conf.SpotPriceBufferPercentage,
 		conf.BiddingPolicy,
 		conf.FilterByTags,
+		conf.TagFilteringMode,
 		conf.SpotProductDescription)
 
 	autospotting.Run(conf.Config)
@@ -146,14 +148,24 @@ func (c *cfgData) parseCommandLineFlags() {
 
 	flag.StringVar(&c.SpotProductDescription, "spot_product_description", autospotting.DefaultSpotProductDescription,
 		"\n\tThe Spot Product or operating system to use when looking up spot price history in the market.\n"+
-			"\tValid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) | SUSE Linux (Amazon VPC) | Windows (Amazon VPC)\n")
+			"\tValid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) | \n"+
+			"\tSUSE Linux (Amazon VPC) | Windows (Amazon VPC)\n"+
+			"\tDefault value: "+autospotting.DefaultSpotProductDescription+"\n")
 
 	flag.StringVar(&c.BiddingPolicy, "bidding_policy", autospotting.DefaultBiddingPolicy,
 		"\n\tPolicy choice for spot bid. If set to 'normal', we bid at the on-demand price.\n"+
-			"\tIf set to 'aggressive', we bid at a percentage value above the spot price configurable using the spot_price_buffer_percentage.\n")
+			"\tIf set to 'aggressive', we bid at a percentage value above the spot price \n"+
+			"\tconfigurable using the spot_price_buffer_percentage.\n")
 
-	flag.StringVar(&c.FilterByTags, "tag_filters", "", "Set of tags to filter the ASGs on.  Default if no value is set will be the equivalent of -tag_filters 'spot-enabled=true'\n\t"+
-		"Example: ./autospotting --tag_filters 'spot-enabled=true,Environment=dev,Team=vision'\n")
+	flag.StringVar(&c.FilterByTags, "tag_filters", "", "\n\tSet of tags to filter the ASGs on.\n"+
+		"\tDefault if no value is set will be the equivalent of -tag_filters 'spot-enabled=true'\n"+
+		"\tIn case the tag_filtering_mode is set to opt-out, it defaults to 'spot-enabled=false'\n"+
+		"\tExample: ./autospotting --tag_filters 'spot-enabled=true,Environment=dev,Team=vision'\n")
+
+	flag.StringVar(&c.TagFilteringMode, "tag_filtering_mode", "opt-in",
+		"\n\tControls the behavior of the tag_filters option. \n"+
+			"\tValid choices: 'opt-in' | 'opt-out'. Default value: 'opt-in'\n"+
+			"\tExample: ./autospotting --tag_filtering_mode 'opt-out'\n")
 
 	v := flag.Bool("version", false, "Print version number and exit.\n")
 

--- a/autospotting.go
+++ b/autospotting.go
@@ -104,76 +104,56 @@ func (c *cfgData) initialize() {
 }
 
 func (c *cfgData) parseCommandLineFlags() {
-
 	flag.StringVar(&c.Regions, "regions", "",
-		"\n\tRegions where it should be activated (comma or whitespace separated list, "+
-			"also supports globs), by default it runs on all regions.\n\t"+
+		"\n\tRegions where it should be activated (separated by comma or whitespace, "+
+			"also supports globs). By default it runs on all regions.\n\t"+
 			"Example: ./autospotting -regions 'eu-*,us-east-1'\n")
-
 	flag.Int64Var(&c.MinOnDemandNumber, "min_on_demand_number", autospotting.DefaultMinOnDemandValue,
-		"\n\tOn-demand capacity (as absolute number) ensured to be running in each of your groups.\n\t"+
-			"Can be overridden on a per-group basis using the tag "+
-			autospotting.OnDemandNumberLong+".\n")
-
+		"\n\tNumber of on-demand nodes to be kept running in each of your groups.\n\t"+
+			"Can be overridden on a per-group basis using the tag "+autospotting.OnDemandNumberLong+".\n")
 	flag.Float64Var(&c.MinOnDemandPercentage, "min_on_demand_percentage", 0.0,
-		"\n\tOn-demand capacity (percentage of the total number of instances in the group) "+
-			"ensured to be running in each of your groups.\n\t"+
-			"Can be overridden on a per-group basis using the tag "+
-			autospotting.OnDemandPercentageTag+
+		"\n\tPpercentage of the total number of instances in each group to be kept on-demand\n\t"+
+			"Can be overridden on a per-group basis using the tag "+autospotting.OnDemandPercentageTag+
 			"\n\tIt is ignored if min_on_demand_number is also set.\n")
-
 	flag.StringVar(&c.AllowedInstanceTypes, "allowed_instance_types", "",
-		"\n\tIf specified, the spot instances will be of these types.\n"+
-			"\tIf missing, the type is autodetected frome each ASG based on it's Launch Configuration.\n"+
+		"\n\tIf specified, the spot instances will be searched only among these types.\n\tIf missing, any instance type is allowed.\n"+
 			"\tAccepts a list of comma or whitespace seperated instance types (supports globs).\n"+
 			"\tExample: ./autospotting -allowed_instance_types 'c5.*,c4.xlarge'\n")
-
 	flag.StringVar(&c.DisallowedInstanceTypes, "disallowed_instance_types", "",
 		"\n\tIf specified, the spot instances will _never_ be of these types.\n"+
 			"\tAccepts a list of comma or whitespace seperated instance types (supports globs).\n"+
 			"\tExample: ./autospotting -disallowed_instance_types 't2.*,c4.xlarge'\n")
-
 	flag.Float64Var(&c.OnDemandPriceMultiplier, "on_demand_price_multiplier", 1.0,
-		"\n\tMultiplier for the on-demand price. This is useful for volume discounts or if you want to\n"+
-			"\tset your bid price to be higher than the on demand price to reduce the chances that your\n"+
-			"\tspot instances will be terminated.\n")
-
+		"\n\tMultiplier for the on-demand price. Numbers less than 1.0 are useful for volume discounts.\n"+
+			"\tExample: ./autospotting -on_demand_price_multiplier 0.6 will have the on-demand price "+
+			"considered at 60% of the actual value.")
 	flag.Float64Var(&c.SpotPriceBufferPercentage, "spot_price_buffer_percentage", autospotting.DefaultSpotPriceBufferPercentage,
-		"\n\tPercentage Value of the bid above the current spot price. A spot bid would be placed at a value :\n"+
-			"\tcurrent_spot_price * [1 + (spot_price_buffer_percentage/100.0)]. The main benefit is that\n"+
-			"\tit protects the group from running spot instances that got significantly more expensive than\n"+
-			"\twhen they were initially launched, but still somewhat less than the on-demand price. Can be\n"+
-			"\tenforced using the tag: "+autospotting.SpotPriceBufferPercentageTag+". If the bid exceeds\n"+
-			"\tthe on-demand price, we place a bid at on-demand price itself.\n")
-
+		"\n\tBid a given percentage above the current spot price.\n\tProtects the group from running spot\n"+
+			"\tinstances that got significantly more expensive than when they were initially launched\n"+
+			"\tThe tag "+autospotting.SpotPriceBufferPercentageTag+" can be used to override this on a group level.\n"+
+			"If the bid exceeds the on-demand price, we place a bid at on-demand price itself.\n")
 	flag.StringVar(&c.SpotProductDescription, "spot_product_description", autospotting.DefaultSpotProductDescription,
-		"\n\tThe Spot Product or operating system to use when looking up spot price history in the market.\n"+
+		"\n\tThe Spot Product to use when looking up spot price history in the market.\n"+
 			"\tValid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) | \n"+
-			"\tSUSE Linux (Amazon VPC) | Windows (Amazon VPC)\n"+
-			"\tDefault value: "+autospotting.DefaultSpotProductDescription+"\n")
-
+			"\tSUSE Linux (Amazon VPC) | Windows (Amazon VPC)\n\tDefault value: "+autospotting.DefaultSpotProductDescription+"\n")
 	flag.StringVar(&c.BiddingPolicy, "bidding_policy", autospotting.DefaultBiddingPolicy,
-		"\n\tPolicy choice for spot bid. If set to 'normal', we bid at the on-demand price.\n"+
+		"\n\tPolicy choice for spot bid. If set to 'normal', we bid at the on-demand price(times the multiplier).\n"+
 			"\tIf set to 'aggressive', we bid at a percentage value above the spot price \n"+
 			"\tconfigurable using the spot_price_buffer_percentage.\n")
-
 	flag.StringVar(&c.FilterByTags, "tag_filters", "", "\n\tSet of tags to filter the ASGs on.\n"+
 		"\tDefault if no value is set will be the equivalent of -tag_filters 'spot-enabled=true'\n"+
 		"\tIn case the tag_filtering_mode is set to opt-out, it defaults to 'spot-enabled=false'\n"+
 		"\tExample: ./autospotting --tag_filters 'spot-enabled=true,Environment=dev,Team=vision'\n")
-
-	flag.StringVar(&c.TagFilteringMode, "tag_filtering_mode", "opt-in",
-		"\n\tControls the behavior of the tag_filters option. \n"+
-			"\tValid choices: 'opt-in' | 'opt-out'. Default value: 'opt-in'\n"+
-			"\tExample: ./autospotting --tag_filtering_mode 'opt-out'\n")
-
+	flag.StringVar(&c.TagFilteringMode, "tag_filtering_mode", "opt-in", "\n\tControls the behavior of the tag_filters option.\n"+
+		"\tValid choices: opt-in | opt-out\n\tDefault value: 'opt-in'\n\tExample: ./autospotting --tag_filtering_mode opt-out\n")
 	v := flag.Bool("version", false, "Print version number and exit.\n")
-
 	flag.Parse()
+	printVersion(v)
+}
 
+func printVersion(v *bool) {
 	if *v {
 		fmt.Println("AutoSpotting build:", Version)
 		os.Exit(0)
 	}
-
 }

--- a/autospotting.go
+++ b/autospotting.go
@@ -104,48 +104,48 @@ func (c *cfgData) initialize() {
 }
 
 func (c *cfgData) parseCommandLineFlags() {
-	flag.StringVar(&c.Regions, "regions", "",
-		"\n\tRegions where it should be activated (separated by comma or whitespace, "+
-			"also supports globs). By default it runs on all regions.\n\t"+
-			"Example: ./autospotting -regions 'eu-*,us-east-1'\n")
-	flag.Int64Var(&c.MinOnDemandNumber, "min_on_demand_number", autospotting.DefaultMinOnDemandValue,
-		"\n\tNumber of on-demand nodes to be kept running in each of your groups.\n\t"+
-			"Can be overridden on a per-group basis using the tag "+autospotting.OnDemandNumberLong+".\n")
-	flag.Float64Var(&c.MinOnDemandPercentage, "min_on_demand_percentage", 0.0,
-		"\n\tPpercentage of the total number of instances in each group to be kept on-demand\n\t"+
-			"Can be overridden on a per-group basis using the tag "+autospotting.OnDemandPercentageTag+
-			"\n\tIt is ignored if min_on_demand_number is also set.\n")
 	flag.StringVar(&c.AllowedInstanceTypes, "allowed_instance_types", "",
 		"\n\tIf specified, the spot instances will be searched only among these types.\n\tIf missing, any instance type is allowed.\n"+
 			"\tAccepts a list of comma or whitespace seperated instance types (supports globs).\n"+
 			"\tExample: ./autospotting -allowed_instance_types 'c5.*,c4.xlarge'\n")
-	flag.StringVar(&c.DisallowedInstanceTypes, "disallowed_instance_types", "",
-		"\n\tIf specified, the spot instances will _never_ be of these types.\n"+
-			"\tAccepts a list of comma or whitespace seperated instance types (supports globs).\n"+
-			"\tExample: ./autospotting -disallowed_instance_types 't2.*,c4.xlarge'\n")
-	flag.Float64Var(&c.OnDemandPriceMultiplier, "on_demand_price_multiplier", 1.0,
-		"\n\tMultiplier for the on-demand price. Numbers less than 1.0 are useful for volume discounts.\n"+
-			"\tExample: ./autospotting -on_demand_price_multiplier 0.6 will have the on-demand price "+
-			"considered at 60% of the actual value.")
-	flag.Float64Var(&c.SpotPriceBufferPercentage, "spot_price_buffer_percentage", autospotting.DefaultSpotPriceBufferPercentage,
-		"\n\tBid a given percentage above the current spot price.\n\tProtects the group from running spot\n"+
-			"\tinstances that got significantly more expensive than when they were initially launched\n"+
-			"\tThe tag "+autospotting.SpotPriceBufferPercentageTag+" can be used to override this on a group level.\n"+
-			"If the bid exceeds the on-demand price, we place a bid at on-demand price itself.\n")
-	flag.StringVar(&c.SpotProductDescription, "spot_product_description", autospotting.DefaultSpotProductDescription,
-		"\n\tThe Spot Product to use when looking up spot price history in the market.\n"+
-			"\tValid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) | \n"+
-			"\tSUSE Linux (Amazon VPC) | Windows (Amazon VPC)\n\tDefault value: "+autospotting.DefaultSpotProductDescription+"\n")
 	flag.StringVar(&c.BiddingPolicy, "bidding_policy", autospotting.DefaultBiddingPolicy,
 		"\n\tPolicy choice for spot bid. If set to 'normal', we bid at the on-demand price(times the multiplier).\n"+
 			"\tIf set to 'aggressive', we bid at a percentage value above the spot price \n"+
 			"\tconfigurable using the spot_price_buffer_percentage.\n")
+	flag.StringVar(&c.DisallowedInstanceTypes, "disallowed_instance_types", "",
+		"\n\tIf specified, the spot instances will _never_ be of these types.\n"+
+			"\tAccepts a list of comma or whitespace seperated instance types (supports globs).\n"+
+			"\tExample: ./autospotting -disallowed_instance_types 't2.*,c4.xlarge'\n")
+	flag.Int64Var(&c.MinOnDemandNumber, "min_on_demand_number", autospotting.DefaultMinOnDemandValue,
+		"\n\tNumber of on-demand nodes to be kept running in each of the groups.\n\t"+
+			"Can be overridden on a per-group basis using the tag "+autospotting.OnDemandNumberLong+".\n")
+	flag.Float64Var(&c.MinOnDemandPercentage, "min_on_demand_percentage", 0.0,
+		"\n\tPercentage of the total number of instances in each group to be kept on-demand\n\t"+
+			"Can be overridden on a per-group basis using the tag "+autospotting.OnDemandPercentageTag+
+			"\n\tIt is ignored if min_on_demand_number is also set.\n")
+	flag.Float64Var(&c.OnDemandPriceMultiplier, "on_demand_price_multiplier", 1.0,
+		"\n\tMultiplier for the on-demand price. Numbers less than 1.0 are useful for volume discounts.\n"+
+			"\tExample: ./autospotting -on_demand_price_multiplier 0.6 will have the on-demand price "+
+			"considered at 60% of the actual value.\n")
+	flag.StringVar(&c.Regions, "regions", "",
+		"\n\tRegions where it should be activated (separated by comma or whitespace, also supports globs).\n"+
+			"\tBy default it runs on all regions.\n"+
+			"\tExample: ./autospotting -regions 'eu-*,us-east-1'\n")
+	flag.Float64Var(&c.SpotPriceBufferPercentage, "spot_price_buffer_percentage", autospotting.DefaultSpotPriceBufferPercentage,
+		"\n\tBid a given percentage above the current spot price.\n\tProtects the group from running spot"+
+			"instances that got significantly more expensive than when they were initially launched\n"+
+			"\tThe tag "+autospotting.SpotPriceBufferPercentageTag+" can be used to override this on a group level.\n"+
+			"\tIf the bid exceeds the on-demand price, we place a bid at on-demand price itself.\n")
+	flag.StringVar(&c.SpotProductDescription, "spot_product_description", autospotting.DefaultSpotProductDescription,
+		"\n\tThe Spot Product to use when looking up spot price history in the market.\n"+
+			"\tValid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) | \n"+
+			"\tSUSE Linux (Amazon VPC) | Windows (Amazon VPC)\n\tDefault value: "+autospotting.DefaultSpotProductDescription+"\n")
+	flag.StringVar(&c.TagFilteringMode, "tag_filtering_mode", "opt-in", "\n\tControls the behavior of the tag_filters option.\n"+
+		"\tValid choices: opt-in | opt-out\n\tDefault value: 'opt-in'\n\tExample: ./autospotting --tag_filtering_mode opt-out\n")
 	flag.StringVar(&c.FilterByTags, "tag_filters", "", "\n\tSet of tags to filter the ASGs on.\n"+
 		"\tDefault if no value is set will be the equivalent of -tag_filters 'spot-enabled=true'\n"+
 		"\tIn case the tag_filtering_mode is set to opt-out, it defaults to 'spot-enabled=false'\n"+
 		"\tExample: ./autospotting --tag_filters 'spot-enabled=true,Environment=dev,Team=vision'\n")
-	flag.StringVar(&c.TagFilteringMode, "tag_filtering_mode", "opt-in", "\n\tControls the behavior of the tag_filters option.\n"+
-		"\tValid choices: opt-in | opt-out\n\tDefault value: 'opt-in'\n\tExample: ./autospotting --tag_filtering_mode opt-out\n")
 	v := flag.Bool("version", false, "Print version number and exit.\n")
 	flag.Parse()
 	printVersion(v)

--- a/cloudformation/stacks/AutoSpotting/template.json
+++ b/cloudformation/stacks/AutoSpotting/template.json
@@ -93,7 +93,16 @@
       "Default": "",
       "Description": "Comma separated list of tag=value on which to filter the ASGs that autospotting considers.  By default (if no filters are specific) then 'spot-enabled=true' is used.  Example: 'spot-enabled=true,environment=dev'",
       "Type": "String"
-    }
+      },
+    "TagFilteringMode": {
+        "Description": "Controls the behavior against the AutoScaling groups tagged as per the FilterByTags option. Defaults to 'opt-in', only processing the tagged groups. The opposite behavior can be configured using the opt-out mode",
+        "Type": "String",
+        "Default": "opt-in",
+        "AllowedValues" : [
+          "opt-in",
+          "opt-out"
+        ]
+      }
   },
   "Resources": {
     "LambdaExecutionRole": {
@@ -131,7 +140,8 @@
             "REGIONS": { "Ref": "Regions" },
             "ALLOWED_INSTANCE_TYPES": { "Ref": "AllowedInstanceTypes" },
             "DISALLOWED_INSTANCE_TYPES": { "Ref": "DisallowedInstanceTypes" },
-            "TAG_FILTERS": { "Ref": "FilterByTags" }
+            "TAG_FILTERS": { "Ref": "FilterByTags" },
+            "TAG_FILTERING_MODE": { "Ref": "TagFilteringMode" }
           }
         },
         "Handler": { "Ref": "LambdaHandlerFunction" },

--- a/core/config.go
+++ b/core/config.go
@@ -39,4 +39,7 @@ type Config struct {
 	// Filter on ASG tags
 	// for example: spot-enabled=true,environment=dev,team=interactive
 	FilterByTags string
+	// Controls how are the tags used to filter the groups.
+	// Available options: 'opt-in' and 'opt-out', default: 'opt-in'
+	TagFilteringMode string
 }

--- a/core/main.go
+++ b/core/main.go
@@ -27,6 +27,7 @@ func Run(cfg *Config) {
 	// use this only to list all the other regions
 	ec2Conn := connectEC2(cfg.MainRegion)
 
+	addDefaultFilteringMode(cfg)
 	addDefaultFilter(cfg)
 
 	allRegions, err := getRegions(ec2Conn)
@@ -40,9 +41,20 @@ func Run(cfg *Config) {
 
 }
 
+func addDefaultFilteringMode(cfg *Config) {
+	if cfg.TagFilteringMode == "" {
+		cfg.TagFilteringMode = "opt-in"
+	}
+}
+
 func addDefaultFilter(cfg *Config) {
 	if len(strings.TrimSpace(cfg.FilterByTags)) == 0 {
-		cfg.FilterByTags = "spot-enabled=true"
+		switch cfg.TagFilteringMode {
+		case "opt-out":
+			cfg.FilterByTags = "spot-enabled=false"
+		default:
+			cfg.FilterByTags = "spot-enabled=true"
+		}
 	}
 }
 

--- a/core/main.go
+++ b/core/main.go
@@ -42,8 +42,12 @@ func Run(cfg *Config) {
 }
 
 func addDefaultFilteringMode(cfg *Config) {
-	if cfg.TagFilteringMode == "" {
+	if cfg.TagFilteringMode != "opt-out" {
+		debug.Printf("Configured filtering mode: '%s', considering it as 'opt-in'(default)\n",
+			cfg.TagFilteringMode)
 		cfg.TagFilteringMode = "opt-in"
+	} else {
+		debug.Println("Configured filtering mode: 'opt-out'")
 	}
 }
 

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -128,6 +128,13 @@ func Test_addDefaultFilterMode(t *testing.T) {
 			},
 			want: "opt-out",
 		},
+		{
+			name: "Anything else gives the opt-in FilterMode",
+			cfg: Config{
+				TagFilteringMode: "whatever",
+			},
+			want: "opt-in",
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -84,6 +84,11 @@ func Test_spotEnabledIsAddedByDefault(t *testing.T) {
 			},
 			want: "spot-enabled=true",
 		},
+		{
+			name:   "Default No ASG Tags",
+			config: Config{TagFilteringMode: "opt-out"},
+			want:   "spot-enabled=false",
+		},
 	}
 
 	for _, tt := range tests {
@@ -93,6 +98,44 @@ func Test_spotEnabledIsAddedByDefault(t *testing.T) {
 
 			if !reflect.DeepEqual(tt.config.FilterByTags, tt.want) {
 				t.Errorf("addDefaultFilter() = %v, want %v", tt.config.FilterByTags, tt.want)
+			}
+		})
+	}
+}
+
+func Test_addDefaultFilterMode(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "Missing FilterMode",
+			cfg:  Config{TagFilteringMode: ""},
+			want: "opt-in",
+		},
+		{
+			name: "Opt-in FilterMode",
+			cfg: Config{
+				TagFilteringMode: "opt-in",
+			},
+			want: "opt-in",
+		},
+		{
+			name: "Opt-out FilterMode",
+			cfg: Config{
+				TagFilteringMode: "opt-out",
+			},
+			want: "opt-out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addDefaultFilteringMode(&tt.cfg)
+			if !reflect.DeepEqual(tt.cfg.TagFilteringMode, tt.want) {
+				t.Errorf("addDefaultFilteringMode() = %v, want %v",
+					tt.cfg.TagFilteringMode, tt.want)
 			}
 		})
 	}

--- a/core/region_test.go
+++ b/core/region_test.go
@@ -436,6 +436,50 @@ func TestFilterAsgs(t *testing.T) {
 			},
 		},
 		{
+			name: "Test opt-out mode",
+			// Run on all groups except for those tagged with spot-enabled=false
+			want: []string{"asg2", "asg3", "asg4"},
+			tregion: &region{
+				tagsToFilterASGsBy: []Tag{{Key: "spot-enabled", Value: "false"}},
+				conf:               &Config{TagFilteringMode: "opt-out"},
+				services: connections{
+					autoScaling: mockASG{
+						dasgo: &autoscaling.DescribeAutoScalingGroupsOutput{
+							AutoScalingGroups: []*autoscaling.Group{
+								{
+									Tags: []*autoscaling.TagDescription{
+										{Key: aws.String("environment"), Value: aws.String("dev"), ResourceId: aws.String("asg1")},
+										{Key: aws.String("spot-enabled"), Value: aws.String("false"), ResourceId: aws.String("asg1")},
+									},
+									AutoScalingGroupName: aws.String("asg1"),
+								},
+								{
+									Tags: []*autoscaling.TagDescription{
+										{Key: aws.String("environment"), Value: aws.String("dev"), ResourceId: aws.String("asg2")},
+										{Key: aws.String("spot-enabled"), Value: aws.String("true"), ResourceId: aws.String("asg2")},
+									},
+									AutoScalingGroupName: aws.String("asg2"),
+								},
+								{
+									Tags: []*autoscaling.TagDescription{
+										{Key: aws.String("environment"), Value: aws.String("qa"), ResourceId: aws.String("asg3")},
+									},
+									AutoScalingGroupName: aws.String("asg3"),
+								},
+								{
+									Tags: []*autoscaling.TagDescription{
+										{Key: aws.String("environment"), Value: aws.String("qa"), ResourceId: aws.String("asg4")},
+									},
+									AutoScalingGroupName: aws.String("asg4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
 			name: "Test with two filters",
 			want: []string{"asg3", "asg4"},
 			tregion: &region{

--- a/core/region_test.go
+++ b/core/region_test.go
@@ -438,7 +438,7 @@ func TestFilterAsgs(t *testing.T) {
 		{
 			name: "Test opt-out mode",
 			// Run on all groups except for those tagged with spot-enabled=false
-			want: []string{"asg2", "asg3", "asg4"},
+			want: []string{"asg2", "asg3"},
 			tregion: &region{
 				tagsToFilterASGsBy: []Tag{{Key: "spot-enabled", Value: "false"}},
 				conf:               &Config{TagFilteringMode: "opt-out"},
@@ -469,6 +469,7 @@ func TestFilterAsgs(t *testing.T) {
 								{
 									Tags: []*autoscaling.TagDescription{
 										{Key: aws.String("environment"), Value: aws.String("qa"), ResourceId: aws.String("asg4")},
+										{Key: aws.String("spot-enabled"), Value: aws.String("false"), ResourceId: aws.String("asg4")},
 									},
 									AutoScalingGroupName: aws.String("asg4"),
 								},
@@ -478,7 +479,59 @@ func TestFilterAsgs(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			name: "Test opt-out mode with multiple tag filters",
+			// Run on all groups except for those tagged with spot-enabled=false and
+			// environment=dev, regardless of other tags that may be set
+			want: []string{"asg2", "asg3", "asg4"},
+			tregion: &region{
+				tagsToFilterASGsBy: []Tag{
+					{Key: "spot-enabled", Value: "false"},
+					{Key: "environment", Value: "dev"},
+				},
+				conf: &Config{TagFilteringMode: "opt-out"},
+				services: connections{
+					autoScaling: mockASG{
+						dasgo: &autoscaling.DescribeAutoScalingGroupsOutput{
+							AutoScalingGroups: []*autoscaling.Group{
+								{
+									Tags: []*autoscaling.TagDescription{
+										{Key: aws.String("spot-enabled"), Value: aws.String("false"), ResourceId: aws.String("asg1")},
+										{Key: aws.String("environment"), Value: aws.String("dev"), ResourceId: aws.String("asg1")},
+										{Key: aws.String("team"), Value: aws.String("awesome"), ResourceId: aws.String("asg1")},
+									},
+									AutoScalingGroupName: aws.String("asg1"),
+								},
+								{
+									Tags: []*autoscaling.TagDescription{
+										{Key: aws.String("environment"), Value: aws.String("dev"), ResourceId: aws.String("asg2")},
+										{Key: aws.String("spot-enabled"), Value: aws.String("true"), ResourceId: aws.String("asg2")},
+										{Key: aws.String("team"), Value: aws.String("awesome"), ResourceId: aws.String("asg2")},
+									},
+									AutoScalingGroupName: aws.String("asg2"),
+								},
+								{
+									Tags: []*autoscaling.TagDescription{
+										{Key: aws.String("spot-enabled"), Value: aws.String("false"), ResourceId: aws.String("asg3")},
+										{Key: aws.String("environment"), Value: aws.String("qa"), ResourceId: aws.String("asg3")},
+										{Key: aws.String("team"), Value: aws.String("awesome"), ResourceId: aws.String("asg3")},
+									},
+									AutoScalingGroupName: aws.String("asg3"),
+								},
+								{
+									Tags: []*autoscaling.TagDescription{
+										{Key: aws.String("environment"), Value: aws.String("qa"), ResourceId: aws.String("asg4")},
+										{Key: aws.String("spot-enabled"), Value: aws.String("true"), ResourceId: aws.String("asg4")},
+										{Key: aws.String("team"), Value: aws.String("awesome"), ResourceId: aws.String("asg4")},
+									},
+									AutoScalingGroupName: aws.String("asg4"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		{
 			name: "Test with two filters",
 			want: []string{"asg3", "asg4"},

--- a/terraform/autospotting.tf
+++ b/terraform/autospotting.tf
@@ -11,6 +11,7 @@ module "autospotting" {
   autospotting_bidding_policy               = "${var.asg_bidding_policy}"
   autospotting_regions_enabled              = "${var.asg_regions_enabled}"
   autospotting_tag_filters                  = "${var.asg_tag_filters}"
+  autospotting_tag_filtering_mode           = "${var.asg_tag_filtering_mode}"
 
   lambda_zipname       = "${var.lambda_zipname}"
   lambda_s3_bucket     = "${var.lambda_s3_bucket}"

--- a/terraform/autospotting/lambda.tf
+++ b/terraform/autospotting/lambda.tf
@@ -21,6 +21,7 @@ module "aws_lambda_function" {
   autospotting_bidding_policy               = "${var.autospotting_bidding_policy}"
   autospotting_regions_enabled              = "${var.autospotting_regions_enabled}"
   autospotting_tag_filters                  = "${var.autospotting_tag_filters}"
+  autospotting_tag_filtering_mode           = "${var.autospotting_tag_filtering_mode}"
 }
 
 resource "aws_iam_role" "autospotting_role" {

--- a/terraform/autospotting/lambda/main.tf
+++ b/terraform/autospotting/lambda/main.tf
@@ -22,6 +22,7 @@ resource "aws_lambda_function" "autospotting" {
       BIDDING_POLICY               = "${var.autospotting_bidding_policy}"
       REGIONS                      = "${var.autospotting_regions_enabled}"
       TAG_FILTERS                  = "${var.autospotting_tag_filters}"
+      TAG_FILTERING_MODE           = "${var.autospotting_tag_filtering_mode}"
     }
   }
 }
@@ -29,14 +30,14 @@ resource "aws_lambda_function" "autospotting" {
 resource "aws_lambda_function" "autospotting_from_s3" {
   count = "${var.lambda_s3_bucket == "" ? 0 : 1}"
 
-  function_name    = "autospotting"
-  s3_bucket        = "${var.lambda_s3_bucket}"
-  s3_key           = "${var.lambda_s3_key}"
-  role             = "${var.lambda_role_arn}"
-  runtime          = "${var.lambda_runtime}"
-  timeout          = "${var.lambda_timeout}"
-  handler          = "autospotting"
-  memory_size      = "${var.lambda_memory_size}"
+  function_name = "autospotting"
+  s3_bucket     = "${var.lambda_s3_bucket}"
+  s3_key        = "${var.lambda_s3_key}"
+  role          = "${var.lambda_role_arn}"
+  runtime       = "${var.lambda_runtime}"
+  timeout       = "${var.lambda_timeout}"
+  handler       = "autospotting"
+  memory_size   = "${var.lambda_memory_size}"
 
   environment {
     variables = {
@@ -50,6 +51,7 @@ resource "aws_lambda_function" "autospotting_from_s3" {
       BIDDING_POLICY               = "${var.autospotting_bidding_policy}"
       REGIONS                      = "${var.autospotting_regions_enabled}"
       TAG_FILTERS                  = "${var.autospotting_tag_filters}"
+      TAG_FILTERING_MODE           = "${var.autospotting_tag_filtering_mode}"
     }
   }
 }

--- a/terraform/autospotting/lambda/variables.tf
+++ b/terraform/autospotting/lambda/variables.tf
@@ -25,3 +25,4 @@ variable "autospotting_spot_product_description" {}
 variable "autospotting_bidding_policy" {}
 variable "autospotting_regions_enabled" {}
 variable "autospotting_tag_filters" {}
+variable "autospotting_tag_filtering_mode" {}

--- a/terraform/autospotting/variables.tf
+++ b/terraform/autospotting/variables.tf
@@ -9,6 +9,7 @@ Example: 't2.*,m4.large'
 Using the 'current' magic value will only allow the same type as the
 on-demand instances set in the group's launch configuration.
 EOF
+
   default = ""
 }
 
@@ -19,6 +20,7 @@ in case you want to exclude specific types (also support globs).
 
 Example: 't2.*,m4.large'
 EOF
+
   default = ""
 }
 
@@ -47,7 +49,24 @@ variable "autospotting_regions_enabled" {
 }
 
 variable "autospotting_tag_filters" {
-  description = "tags to filter which ASGs autospotting considers.  by default if left blank, asgs tagged with spot-enbled=true will be operated on.  You can set this to many tags, for example: spot-enabled=true,Environment=dev,Team=vision"
+  description = <<EOF
+  Tags to filter which ASGs autospotting considers. By default, ASGs tagged
+  with spot-enbled=true will be operated on. In opt-out mode it operates on
+  all groups except those tagged with spot-enbled=false.
+
+  You can set this to many tags, for example:
+  spot-enabled=true,Environment=dev,Team=vision"
+  EOF
+}
+
+variable "autospotting_tag_filtering_mode" {
+  description = <<EOF
+  Controls the tag-based ASG filter. Supported values: 'opt-in' or 'opt-out'.
+  Defaults to opt-in mode, in which it only acts against the tagged groups. In
+  opt-out mode it works against all groups except for the tagged ones.
+  Use the opt-out mode carefully!
+  EOF
+  default = "opt-in"
 }
 
 variable "autospotting_spot_product_description" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,9 +4,12 @@ variable "asg_allowed_instance_types" {
 Comma separated list of allowed instance types for spot requests,
 in case you want to allow specific types (also support globs).
 
-Example: 't2.*,m4.large' or special value: 'current': the same as initial on-demand instances
+Example: 't2.*,m4.large' or special value: 'current': the same as initial
+on-demand instances.
+
 EOF
-  default     = ""
+
+  default = ""
 }
 
 variable "asg_disallowed_instance_types" {
@@ -16,6 +19,7 @@ in case you want to exclude specific types (also support globs).
 
 Example: 't2.*,m4.large'
 EOF
+
   default = ""
 }
 
@@ -35,8 +39,15 @@ variable "asg_on_demand_price_multiplier" {
 }
 
 variable "asg_spot_product_description" {
-  description = "The Spot Product or operating system to use when looking up spot price history in the market. Valid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) | SUSE Linux (Amazon VPC) | Windows (Amazon VPC)"
-  default     = "Linux/UNIX (Amazon VPC)"
+  description = <<EOF
+  The Spot Product or operating system to use when looking
+  up spot price history in the market.
+
+  Valid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) |
+  SUSE Linux (Amazon VPC) | Windows (Amazon VPC)
+  EOF
+
+  default = "Linux/UNIX (Amazon VPC)"
 }
 
 variable "asg_spot_price_buffer_percentage" {
@@ -55,8 +66,26 @@ variable "asg_regions_enabled" {
 }
 
 variable "asg_tag_filters" {
-  description = "Tags to filter which ASGs autospotting considers.  If blank by default this will search for asgs with spot-enabled=true.  You can set this to many tags, for example: spot-enabled=true,Environment=dev,Team=vision"
-  default     = ""
+  description = <<EOF
+  Tags to filter which ASGs autospotting considers. If blank
+  by default this will search for asgs with spot-enabled=true (when in opt-in
+  mode) and will skip those tagged with spot-enabled=false when in opt-out mode.
+
+  You can set this to many tags, for example:
+  spot-enabled=true,Environment=dev,Team=vision
+  EOF
+
+  default = ""
+}
+
+variable "asg_tag_filtering_mode" {
+  description = <<EOF
+  Controls the tag-based ASG filter. Supported values: 'opt-in' or 'opt-out'.
+  Defaults to opt-in mode, in which it only acts against the tagged groups. In
+  opt-out mode it works against all groups except for the tagged ones.
+  EOF
+
+  default = "opt-in"
 }
 
 # Lambda configuration


### PR DESCRIPTION
Implements #242.

# Issue Type

- Feature Pull Request

## Summary

Implements #242, see that for more details.

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
