### PR TITLE
use TerminateInstanceInAutoScalingGroup instead of Detach

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -598,15 +598,15 @@ func (a *autoScalingGroup) attachSpotInstance(spotInstanceID string) error {
 	return nil
 }
 
-// Terminates an on-demand instance from the group,
-// but only after it was detached from the autoscaling group
+// Terminates an on-demand instance from the group using the
+// TerminateInstanceInAutoScalingGroup api call.
 func (a *autoScalingGroup) terminateInstanceInAutoScalingGroup(
 	instanceID *string) error {
 	logger.Println(a.region.name,
 		a.name,
-		"Detaching and terminating instance:",
+		"Terminating instance:",
 		*instanceID)
-	// detach the on-demand instance
+	// terminate the on-demand instance
 	terminateParams := autoscaling.TerminateInstanceInAutoScalingGroupInput{
 		InstanceId:                     instanceID,
 		ShouldDecrementDesiredCapacity: aws.Bool(true),

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -618,8 +618,6 @@ func (a *autoScalingGroup) terminateInstanceInAutoScalingGroup(
 		return err
 	}
 
-	// Wait till detachment initialize is complete before terminate instance
-	time.Sleep(20 * time.Second * a.region.conf.SleepMultiplier)
 	return nil
 }
 

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -289,7 +289,7 @@ func (a *autoScalingGroup) needReplaceOnDemandInstances() bool {
 		logger.Println("Currently OnDemand running equals to the required number, skipping run")
 		return false
 	}
-	logger.Println("Currently less OnDemand instances than required !")
+	logger.Println("Currently fewer OnDemand instances than required !")
 	if a.allInstanceRunning() && a.instances.count64() >= *a.DesiredCapacity {
 		logger.Println("All instances are running and desired capacity is satisfied")
 		if randomSpot := a.getAnySpotInstance(); randomSpot != nil {
@@ -298,7 +298,7 @@ func (a *autoScalingGroup) needReplaceOnDemandInstances() bool {
 			} else {
 				logger.Println("Terminating a random spot instance",
 					*randomSpot.Instance.InstanceId)
-				randomSpot.terminate()
+				a.terminateInstanceInAutoScalingGroup(randomSpot.Instance.InstanceId)
 			}
 		}
 	}
@@ -433,7 +433,7 @@ func (a *autoScalingGroup) replaceOnDemandInstanceWithSpot(
 		defer a.attachSpotInstance(spotInstanceID)
 	}
 
-	return a.detachAndTerminateOnDemandInstance(odInst.InstanceId)
+	return a.terminateInstanceInAutoScalingGroup(odInst.InstanceId)
 }
 
 // Returns the information about the first running instance found in
@@ -600,32 +600,27 @@ func (a *autoScalingGroup) attachSpotInstance(spotInstanceID string) error {
 
 // Terminates an on-demand instance from the group,
 // but only after it was detached from the autoscaling group
-func (a *autoScalingGroup) detachAndTerminateOnDemandInstance(
+func (a *autoScalingGroup) terminateInstanceInAutoScalingGroup(
 	instanceID *string) error {
 	logger.Println(a.region.name,
 		a.name,
 		"Detaching and terminating instance:",
 		*instanceID)
 	// detach the on-demand instance
-	detachParams := autoscaling.DetachInstancesInput{
-		AutoScalingGroupName: aws.String(a.name),
-		InstanceIds: []*string{
-			instanceID,
-		},
+	terminateParams := autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     instanceID,
 		ShouldDecrementDesiredCapacity: aws.Bool(true),
 	}
 
 	asSvc := a.region.services.autoScaling
-
-	if _, err := asSvc.DetachInstances(&detachParams); err != nil {
+	if _, err := asSvc.TerminateInstanceInAutoScalingGroup(&terminateParams); err != nil {
 		logger.Println(err.Error())
 		return err
 	}
 
 	// Wait till detachment initialize is complete before terminate instance
 	time.Sleep(20 * time.Second * a.region.conf.SleepMultiplier)
-
-	return a.instances.get(*instanceID).terminate()
+	return nil
 }
 
 // Counts the number of already running instances on-demand or spot, in any or a specific AZ.

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -1291,6 +1291,7 @@ func TestNeedReplaceOnDemandInstances(t *testing.T) {
 				services: connections{
 					autoScaling: mockASG{},
 				},
+				conf: &Config{},
 			},
 		},
 		{name: "ASG has just enough on-demand instances running",

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -1196,6 +1196,7 @@ func TestNeedReplaceOnDemandInstances(t *testing.T) {
 		minOnDemand     int64
 		desiredCapacity *int64
 		expectedRun     bool
+		regionASG       *region
 	}{
 		{name: "ASG has no instance at all - 1 on-demand required",
 			asgInstances:    makeInstances(),
@@ -1285,6 +1286,12 @@ func TestNeedReplaceOnDemandInstances(t *testing.T) {
 			minOnDemand:     2,
 			desiredCapacity: aws.Int64(0),
 			expectedRun:     false,
+			regionASG: &region{
+				name: "regionTest",
+				services: connections{
+					autoScaling: mockASG{},
+				},
+			},
 		},
 		{name: "ASG has just enough on-demand instances running",
 			asgInstances: makeInstancesWithCatalog(
@@ -1380,6 +1387,7 @@ func TestNeedReplaceOnDemandInstances(t *testing.T) {
 			a.DesiredCapacity = tt.desiredCapacity
 			a.instances = tt.asgInstances
 			a.minOnDemand = tt.minOnDemand
+			a.region = tt.regionASG
 			shouldRun := a.needReplaceOnDemandInstances()
 			if tt.expectedRun != shouldRun {
 				t.Errorf("needReplaceOnDemandInstances returned: %t expected %t",
@@ -1389,7 +1397,7 @@ func TestNeedReplaceOnDemandInstances(t *testing.T) {
 	}
 }
 
-func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
+func TestTerminateInstanceInAutoScalingGroup(t *testing.T) {
 	tests := []struct {
 		name         string
 		instancesASG instances
@@ -1397,7 +1405,7 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 		instanceID   *string
 		expected     error
 	}{
-		{name: "no err during detach nor terminate",
+		{name: "no err during terminate",
 			instancesASG: makeInstancesWithCatalog(
 				map[string]*instance{
 					"1": {
@@ -1409,7 +1417,7 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 						},
 						region: &region{
 							services: connections{
-								ec2: mockEC2{tierr: nil},
+								ec2: mockEC2{},
 							},
 						},
 					},
@@ -1418,14 +1426,14 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 			regionASG: &region{
 				name: "regionTest",
 				services: connections{
-					autoScaling: mockASG{dierr: nil},
+					autoScaling: mockASG{tiiasgerr: nil},
 				},
 				conf: &Config{},
 			},
 			instanceID: aws.String("1"),
 			expected:   nil,
 		},
-		{name: "err during detach not during terminate",
+		{name: "errors during terminate",
 			instancesASG: makeInstancesWithCatalog(
 				map[string]*instance{
 					"1": {
@@ -1437,7 +1445,7 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 						},
 						region: &region{
 							services: connections{
-								ec2: mockEC2{tierr: nil},
+								ec2: mockEC2{},
 							},
 						},
 					},
@@ -1446,68 +1454,12 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 			regionASG: &region{
 				name: "regionTest",
 				services: connections{
-					autoScaling: mockASG{dierr: errors.New("detach")},
+					autoScaling: mockASG{tiiasgerr: errors.New("terminate-asg")},
 				},
 				conf: &Config{},
 			},
 			instanceID: aws.String("1"),
-			expected:   errors.New("detach"),
-		},
-		{name: "no err during detach but error during terminate",
-			instancesASG: makeInstancesWithCatalog(
-				map[string]*instance{
-					"1": {
-						Instance: &ec2.Instance{
-							InstanceId: aws.String("1"),
-							State: &ec2.InstanceState{
-								Name: aws.String(ec2.InstanceStateNameRunning),
-							},
-						},
-						region: &region{
-							services: connections{
-								ec2: mockEC2{tierr: errors.New("terminate")},
-							},
-						},
-					},
-				},
-			),
-			regionASG: &region{
-				name: "regionTest",
-				services: connections{
-					autoScaling: mockASG{dierr: nil},
-				},
-				conf: &Config{},
-			},
-			instanceID: aws.String("1"),
-			expected:   errors.New("terminate"),
-		},
-		{name: "errors during detach and terminate",
-			instancesASG: makeInstancesWithCatalog(
-				map[string]*instance{
-					"1": {
-						Instance: &ec2.Instance{
-							InstanceId: aws.String("1"),
-							State: &ec2.InstanceState{
-								Name: aws.String(ec2.InstanceStateNameRunning),
-							},
-						},
-						region: &region{
-							services: connections{
-								ec2: mockEC2{tierr: errors.New("terminate")},
-							},
-						},
-					},
-				},
-			),
-			regionASG: &region{
-				name: "regionTest",
-				services: connections{
-					autoScaling: mockASG{dierr: errors.New("detach")},
-				},
-				conf: &Config{},
-			},
-			instanceID: aws.String("1"),
-			expected:   errors.New("detach"),
+			expected:   errors.New("terminate-asg"),
 		},
 	}
 
@@ -1518,7 +1470,7 @@ func TestDetachAndTerminateOnDemandInstance(t *testing.T) {
 				region:    tt.regionASG,
 				instances: tt.instancesASG,
 			}
-			err := a.detachAndTerminateOnDemandInstance(tt.instanceID)
+			err := a.terminateInstanceInAutoScalingGroup(tt.instanceID)
 			CheckErrors(t, err, tt.expected)
 		})
 	}
@@ -2338,10 +2290,10 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 					conf: &Config{},
 					services: connections{
 						autoScaling: &mockASG{
-							uasgo:   nil,
-							uasgerr: nil,
-							dio:     nil,
-							dierr:   nil,
+							uasgo:     nil,
+							uasgerr:   nil,
+							tiiasgo:   nil,
+							tiiasgerr: nil,
 						},
 						ec2: &mockEC2{
 							tio:   nil,
@@ -2438,10 +2390,10 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 					conf: &Config{},
 					services: connections{
 						autoScaling: &mockASG{
-							uasgo:   nil,
-							uasgerr: nil,
-							dio:     nil,
-							dierr:   nil,
+							uasgo:     nil,
+							uasgerr:   nil,
+							tiiasgo:   nil,
+							tiiasgerr: nil,
 						},
 						ec2: &mockEC2{
 							tio:   nil,
@@ -2486,10 +2438,10 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 					conf: &Config{},
 					services: connections{
 						autoScaling: &mockASG{
-							uasgo:   nil,
-							uasgerr: nil,
-							dio:     nil,
-							dierr:   nil,
+							uasgo:     nil,
+							uasgerr:   nil,
+							tiiasgo:   nil,
+							tiiasgerr: nil,
 						},
 					},
 					instances: makeInstancesWithCatalog(
@@ -2539,10 +2491,10 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 					conf: &Config{},
 					services: connections{
 						autoScaling: &mockASG{
-							uasgo:   nil,
-							uasgerr: nil,
-							dio:     nil,
-							dierr:   nil,
+							uasgo:     nil,
+							uasgerr:   nil,
+							tiiasgo:   nil,
+							tiiasgerr: nil,
 						},
 					},
 					instances: makeInstancesWithCatalog(

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -100,9 +100,9 @@ func (m mockEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) 
 // This is useful when methods are doing multiple calls to AWS API
 type mockASG struct {
 	autoscalingiface.AutoScalingAPI
-	// Detach Instances
-	dio   *autoscaling.DetachInstancesOutput
-	dierr error
+	// Terminate Instances
+	tiiasgo   *autoscaling.TerminateInstanceInAutoScalingGroupOutput
+	tiiasgerr error
 	// Attach Instances
 	aio   *autoscaling.AttachInstancesOutput
 	aierr error
@@ -119,8 +119,8 @@ type mockASG struct {
 	dasgo *autoscaling.DescribeAutoScalingGroupsOutput
 }
 
-func (m mockASG) DetachInstances(*autoscaling.DetachInstancesInput) (*autoscaling.DetachInstancesOutput, error) {
-	return m.dio, m.dierr
+func (m mockASG) TerminateInstanceInAutoScalingGroup(*autoscaling.TerminateInstanceInAutoScalingGroupInput) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error) {
+	return m.tiiasgo, m.tiiasgerr
 }
 
 func (m mockASG) AttachInstances(*autoscaling.AttachInstancesInput) (*autoscaling.AttachInstancesOutput, error) {

--- a/terraform/autospotting/autospotting-policy.json
+++ b/terraform/autospotting/autospotting-policy.json
@@ -6,7 +6,7 @@
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:AttachInstances",
-        "autoscaling:DetachInstances",
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:DescribeTags",
         "autoscaling:UpdateAutoScalingGroup",
         "ec2:CreateTags",


### PR DESCRIPTION
# Issue Type
- Feature Pull Request
## Summary

Re-introducing and re-basing the change from #141  that replaces the detach then terminate workflow with the single api call [TerminateInstanceInAutoScalingGroup](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_TerminateInstanceInAutoScalingGroup.html). This patch is running in our custom build of autospotting and has been successfully replacing our prod machines with spot instances consistently and without reproducing the issues that were [previously mentioned](https://github.com/cristim/autospotting/pull/141#issuecomment-339091432). The machines in our ASG scale up and down throughout the day so autospotting has to work as well and it maintains full spot coverage shortly after scale-out actions.

The TerminateInstanceInAutoScalingGroup call is allowing our machines in the ASG to execute their Terminate lifecycle hook before actual termination. This hook tells the machine to start draining ECS tasks which causes them to move the tasks to the spun up spot instance so there is minimal disturbance to our applications. If users had these machines in an [ELB](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-conn-drain.html)/[ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#deregistration-delay), they should do connection draining as well. I confirmed and tested with an instance in an ALB and it stayed in the Termination step until the ALB finished the de-registration delay before the machine was actually shutdown.

Fixes #138 

As this change was previously reverted I would be very happy to help troubleshooting any issues with this patch. Looking at the code I can't see an obvious reason why things would go into a loop of spinning up and then terminating spot instances. More information on maybe how the ASG is setup and the state of it when the loops happens might help.

## Code contribution checklist

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.json)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
