### PR TITLE
Documentation fix for Demand Tags Fixes #253

### DIFF
--- a/START.md
+++ b/START.md
@@ -334,18 +334,18 @@ in the Lambda function's configuration.
 
 On top of the CLI configuration for the on-demand instances, autospotting
 can read those values from the tags of the auto-scaling groups. There are two
-available tags: `autospotting_on_demand_number` and
-`autospotting_on_demand_percentage`.
+available tags: `autospotting_min_on_demand_number` and
+`autospotting_min_on_demand_percentage`.
 
 Just like for the CLI configuration the defined number has a higher priority
 than the percentage value. So the percentage will be ignored if
-`autospotting_on_demand_number` is present and valid.
+`autospotting_min_on_demand_number` is present and valid.
 
 The order of priority from strongest to lowest for minimum on-demand
 configuration is as following:
 
-1. Tag `autospotting_on_demand_number` in ASG
-1. Tag `autospotting_on_demand_percentage` in ASG
+1. Tag `autospotting_min_on_demand_number` in ASG
+1. Tag `autospotting_min_on_demand_percentage` in ASG
 1. Option `-min_on_demand_number` in CLI
 1. Option `-min_on_demand_percentage` in CLI
 

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -79,7 +79,7 @@
       Description: >
         "Minimum on-demand instances (absolute number) to be kept in each of
         your groups. It is a global default value that can be overridden on a
-        per-group basis using the autospotting_on_demand_number tag. It takes
+        per-group basis using the autospotting_min_on_demand_number tag. It takes
         precedence over MinOnDemandPercentage, so it doesn't make sense to pass
         both of them."
       Type: "Number"
@@ -89,7 +89,7 @@
         "Minimum on-demand instances (percentage of the instances currently
         running in each group) that will be kept when replacing with spot
         instances. It is also a global default value that can be overridden on a
-        per-group basis using the autospotting_on_demand_percentage tag.
+        per-group basis using the autospotting_min_on_demand_percentage tag.
         MinOnDemandNumber takes precedence if both these parameters are passed"
       Type: "Number"
     OnDemandPriceMultiplier:


### PR DESCRIPTION
# Issue Type

- Documentation Pull Request

## Summary

The tags for autospotting_min_on_demand_percentage and autospotting_min_on_demand_number were incorrectly specified in the documentation as autospotting_on_demand_percentage and autospotting_on_demand_number. This PR fixes that.

[The code where the actual tags are specified is here.](https://github.com/cristim/autospotting/blob/69ed6177f6d06324e3b962080807977751cb2f21/core/autoscaling.go)

## Code contribution checklist

1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
