### PR TITLE
Fix #260: Handle different wc behaviour of OS X and coreutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ upload: archive                                              ## Upload binary
 .PHONY: upload
 
 vet-check:                                                   ## Verify vet compliance
-ifeq ($(shell go tool vet -all -shadow=true $(GOFILES) 2>&1 | wc -l), 0)
+ifeq ($(shell go tool vet -all -shadow=true $(GOFILES) 2>&1 | wc -l | tr -d '[:space:]'), 0)
 	@printf "ok\tall files passed go vet\n"
 else
 	@printf "error\tsome files did not pass go vet\n"
@@ -70,12 +70,12 @@ endif
 .PHONY: vet-check
 
 fmt-check:                                                   ## Verify fmt compliance
-ifneq ($(shell gofmt -l -s $(GOFILES) | wc -l), 0)
+ifeq ($(shell gofmt -l -s $(GOFILES) | wc -l | tr -d '[:space:]'), 0)
+	@printf "ok\tall files passed go fmt\n"
+else
 	@printf "error\tsome files did not pass go fmt, fix the following formatting diff:\n"
 	@gofmt -l -s -d $(GOFILES)
 	@exit 1
-else
-	@printf "ok\tall files passed go fmt\n"
 endif
 .PHONY: fmt-check
 


### PR DESCRIPTION
# Issue Type
- Bugfix Pull Request

## Summary

Fixes the "Can not build on OSX" issue raised on #260.
The culprit is the wc command provided by OSX.

Also, makes the Makefile a bit more harmonic in its use of ```ifeq```/```ifneq```.

### Details
```
$ gofmt -l -s ./core/config.go ./core/instance.go ./core/launch_configuration.go ./core/connections.go ./core/region.go ./core/region_test.go ./core/instance_test.go ./core/launch_configuration_test.go ./core/connections_test.go ./core/spot_price_test.go ./core/autoscaling_test.go ./core/spot_price.go ./core/mock_test.go ./core/autoscaling.go ./core/main.go ./core/main_test.go ./autospotting.go | wc -l
```
yields

```
       0
```
which is then compared to ```0``` using

```
ifneq ($(shell gofmt -l -s $(GOFILES) | wc -l), 0)
````
Which ends up in the if clause in any case.

Gnu coreutils, included with all Linux-Distros and Homebrew, output the expected ```0``` and thus, the Makefile works.
To fix this  ```tr -d '[:space:]'``` can be used to trim away possible spaces in the output of ```wc -l```.

## Code contribution checklist
I've shortened the list by the non-applicable items.
<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] No issues are reported when running `make full-test`.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
