### PR TITLE
Add "-u" flag to "go get" calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,9 @@ check_deps:                                                  ## Verify the syste
 .PHONY: check_deps
 
 build_deps:
-	@go get github.com/mattn/goveralls
-	@go get github.com/golang/lint/golint
-	@go get golang.org/x/tools/cmd/cover
+	@go get -u github.com/mattn/goveralls
+	@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/tools/cmd/cover
 .PHONY: build_deps
 
 build: build_deps                                            ## Build autospotting binary


### PR DESCRIPTION
If `go get` is running on a machine where package existing in GOPATH, then it will not update the package. To update it flag `-u` should be used.
https://rakyll.org/go-tool-flags/