### PR TITLE
Correct log messages in isReadyToAttach

### DIFF
--- a/core/instance.go
+++ b/core/instance.go
@@ -502,9 +502,14 @@ func (i *instance) isReadyToAttach(asg *autoScalingGroup) bool {
 	if *i.State.Name == ec2.InstanceStateNameRunning &&
 		instanceUpTime > gracePeriod {
 		logger.Println("The spot instance", *i.InstanceId,
+			" has passed grace period and is ready to attach to the group.")
+		return true
+	} else if *i.State.Name == ec2.InstanceStateNameRunning &&
+		instanceUpTime < gracePeriod {
+		logger.Println("The spot instance", *i.InstanceId,
 			"is still in the grace period,",
 			"waiting for it to be ready before we can attach it to the group...")
-		return true
+		return false
 	} else if *i.State.Name == ec2.InstanceStateNamePending {
 		logger.Println("The spot instance", *i.InstanceId,
 			"is still pending,",


### PR DESCRIPTION
# Issue Type
- Bugfix Pull Request

## Summary

The current behaviour is when an instance is still within grace period isReadyToAttach returns false with no log message, as it is the default behaviour of this function. 
The intended log message for an instance still within the grace period is in fact displayed when the grace period has already passed and isReadyToAttach returns true. 

Corrected the log message which is displayed when instance up time has passed the grace period. 
Added an additional message to log when an instance is still within grace period, and return false. as per the previous behaviour.

## Code contribution checklist
1. [] The contribution fixes a single existing github issue, and it is linked
   to it. 
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [x] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
