### PR TITLE
Check ASG min OD rules before launching new spot instance

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -342,6 +342,12 @@ func (a *autoScalingGroup) process() {
 				"No running on-demand instances were found, nothing to do here...")
 			return
 		}
+
+		if !a.needReplaceOnDemandInstances() {
+			logger.Println("Not allowed to replace any of the running OD instances in ", a.name)
+			return
+		}
+
 		a.loadLaunchConfiguration()
 		err := onDemandInstance.launchSpotReplacement()
 		if err != nil {

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -1379,6 +1379,29 @@ func TestNeedReplaceOnDemandInstances(t *testing.T) {
 			desiredCapacity: aws.Int64(4),
 			expectedRun:     true,
 		},
+		{name: "ASG has on-demand instances equal to the min on-demand number",
+			asgInstances: makeInstancesWithCatalog(
+				map[string]*instance{
+					"id-1": {
+						Instance: &ec2.Instance{
+							State:             &ec2.InstanceState{Name: aws.String(ec2.InstanceStateNameRunning)},
+							Placement:         &ec2.Placement{AvailabilityZone: aws.String("eu-west-1a")},
+							InstanceLifecycle: aws.String("on-demand"),
+						},
+					},
+					"id-2": {
+						Instance: &ec2.Instance{
+							State:             &ec2.InstanceState{Name: aws.String(ec2.InstanceStateNameRunning)},
+							Placement:         &ec2.Placement{AvailabilityZone: aws.String("eu-west-1b")},
+							InstanceLifecycle: aws.String("spot"),
+						},
+					},
+				},
+			),
+			minOnDemand:     1,
+			desiredCapacity: aws.Int64(2),
+			expectedRun:     false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request

## Summary

Fixes #290 


## Code contribution checklist

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
