### PR TITLE
Using filter tags with wildcard does not work #246

### DIFF
--- a/core/region.go
+++ b/core/region.go
@@ -284,7 +284,15 @@ func (r *region) requestSpotPrices() error {
 }
 
 func tagsMatch(asgTag *autoscaling.TagDescription, filteringTag Tag) bool {
-	return asgTag != nil && *asgTag.Key == filteringTag.Key && *asgTag.Value == filteringTag.Value
+	if asgTag != nil && *asgTag.Key == filteringTag.Key {
+		matched, err := filepath.Match(filteringTag.Value, *asgTag.Value)
+		if err != nil {
+			logger.Printf("%s Invalid glob expression or text input in filter %s, the instance list may be smaller than expected", filteringTag.Key, filteringTag.Value)
+			return false
+		}
+		return matched
+	}
+	return false
 }
 
 func isASGWithMatchingTag(tagToMatch Tag, asgTags []*autoscaling.TagDescription) bool {


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary
#246 - Using filter tags with wildcard does not work

Add support for using regular expressions to filter instances at the value level for any ASG. The expressions are bounded so a plain string is treated as a basic equality test while a well formed expression needs no bounds, which could be a nuisance on the command line. Expressions are case-sensitive

Rationale is to support broader filtering capabilities and narrowly to service a users needs.

Fixes #246 

### Notes:

`make full-test` failing on mainline `master`. Skipping as a requirement.

