### PR TITLE
Makefile Golint package location broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ check_deps:                                                  ## Verify the syste
 
 build_deps:
 	@go get -u github.com/mattn/goveralls
-	@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/lint/golint
 	@go get -u golang.org/x/tools/cmd/cover
 .PHONY: build_deps
 


### PR DESCRIPTION
- Bugfix Pull Request

go-lint package location changed from github to golang.org

This is to fix this error during builds : package github.com/golang/lint/golint: code in directory /go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"

Golint seems to have updated their package location.